### PR TITLE
feat: complete NodeRegistry interface

### DIFF
--- a/src/NodeRegistry.sol
+++ b/src/NodeRegistry.sol
@@ -47,7 +47,7 @@ contract NodeRegistry is INodeRegistry, AccessControlDefaultAdminRules, ERC721 {
     /// @dev The base URI for the node NFTs.
     string internal _baseTokenURI;
 
-    /// @dev The maximum number of nodes in the canonical network.
+    /// @inheritdoc INodeRegistry
     uint8 public maxActiveNodes = 20;
 
     /**
@@ -62,7 +62,7 @@ contract NodeRegistry is INodeRegistry, AccessControlDefaultAdminRules, ERC721 {
     /// @dev Nodes part of the canonical network.
     EnumerableSet.UintSet internal _canonicalNetworkNodes;
 
-    /// @dev The commission percentage that the node operator receives.
+    /// @inheritdoc INodeRegistry
     uint256 public nodeOperatorCommissionPercent;
 
     constructor(

--- a/src/interfaces/INodeRegistry.sol
+++ b/src/interfaces/INodeRegistry.sol
@@ -236,6 +236,12 @@ interface INodeRegistry is INodeRegistryErrors, INodeRegistryEvents, IERC721 {
     // slither-disable-next-line naming-convention
     function NODE_INCREMENT() external pure returns (uint32 nodeIncrement);
 
+    /// @notice The maximum number of nodes that can be part of the canonical network.
+    function maxActiveNodes() external view returns (uint8 max);
+
+    /// @notice The commission percentage that the node operator receives.
+    function nodeOperatorCommissionPercent() external view returns (uint256 commissionPercent);
+
     /**
      * @notice Gets all nodes regardless of their health status.
      * @return allNodes An array of all nodes in the registry.


### PR DESCRIPTION
## Add maxActiveNodes and nodeOperatorCommissionPercent to NodeRegistry interface
Added interface declarations for `maxActiveNodes()` and `nodeOperatorCommissionPercent()` view functions to `INodeRegistry` interface and updated related documentation in `NodeRegistry` implementation to use @inheritdoc references

### 📍Where to Start
The interface additions in [INodeRegistry.sol](https://github.com/xmtp/smart-contracts/pull/32/files#diff-754fd6a6360372734b9495d23ba9f86aacf43c0211e2a7f1266dd233023698a5)

----

_[Macroscope](https://app.macroscope.com) summarized f7bfd48._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced public accessors to retrieve key node management parameters, making it easier to access details like operational limits and commission settings.
  
- **Documentation**
  - Standardized the API documentation for node configuration to improve clarity and consistency for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->