### PR TITLE
Add xmtpd-anvil docs

### DIFF
--- a/doc/xmtp-anvil-container-image.md
+++ b/doc/xmtp-anvil-container-image.md
@@ -1,0 +1,81 @@
+# XMTP Anvil Baked Image
+
+The XMTP Anvil image aims to provide a stable containerized environment to help the `xmtpd` development process and test locally.
+
+The image contains a baked anvil instance, where all the necessary contracts for XMTP development are deployed.
+
+## Contracts deployed
+
+- [CREATE3Factory](../src/CREATE3Factory.sol)
+- [NodeRegistry](../src/NodeRegistry.sol)
+- [RateRegistry](../src/RateRegistry.sol)
+- [GroupMessageBroadcaster](../src/GroupMessageBroadcaster.sol)
+- [IdentityUpdateBroadcaster](../src/IdentityUpdateBroadcaster.sol)
+
+The `CREATE3Factory` is used to deploy all the contracts, all the addresses are deterministically computed.
+
+## Artifacts
+
+The artifacts included in the image are the following. The paths provided are the full path.
+
+- **anvil state** at `/app/deployments/anvil_localnet/anvil-state.json`
+
+The anvil state can be used to bootstrap an anvil instance as follows:
+
+```shell
+anvil --load-state path/to/anvil-state.json
+```
+
+- **anvil state info file** at `/app/deployments/anvil_localnet/anvil-state-info.json`
+
+The `anvil-state-info.json` file contents are as follows:
+
+```json
+{
+  "create3_factory_address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  "rate_registry_address": "0xE71ac6dE80392495eB52FB1dCa321f5dB8f51BAE",
+  "message_group_broadcaster_address": "0xD5b7B43B0e31112fF99Bd5d5C4f6b828259bedDE",
+  "identity_update_broadcaster_address": "0xe67104BC93003192ab78B797d120DBA6e9Ff4928",
+  "node_registry_address": "0x8d69E9834f1e4b38443C638956F7D81CD04eBB2F"
+}
+```
+
+By parsing the file, or using `jq`, all the contracts can be accessed programmatically.
+
+## Using the image
+
+A new image is created once per release, and pushed to `ghcr.io/xmtp/xmtpd-anvil:TAG`.
+
+### Locally
+
+To pull the image locally, simply run the following command.
+
+```shell
+# Use docker, podman or any other container runtime of choice.
+docker pull ghcr.io/xmtp/xmtpd-anvil:v0.3.0
+```
+
+### As a builder image
+
+To use it as part of a container image build process, add it as `FROM`, as in the next example.
+
+```Dockerfile
+FROM ghcr.io/xmtp/xmtpd-anvil:v0.3.0
+
+RUN <...>
+
+ENTRYPOINT <...>
+```
+
+## Generate a baked anvil state
+
+The anvil state can be manually generated running the following script.
+
+```shell
+dev/gen-anvil-state
+```
+
+The artifacts will be saved in the deployments folder. Note that path are relative paths from the repository root.
+
+- anvil state at `deployments/anvil_localnet/anvil-state.json`
+- anvil state info file at `deployments/anvil_localnet/anvil-state-info.json`


### PR DESCRIPTION
### Add documentation for XMTP Anvil container image to support xmtpd development and local testing
Introduces new documentation files that detail the XMTP Anvil container image functionality:

* [xmtp-anvil-container-image.md](https://github.com/xmtp/smart-contracts/pull/39/files#diff-4ce98f9659c1cf19c1e96d45487b4281bc09b4b22214e894c9fdadc4b9ffd8ac) provides comprehensive documentation for the containerized Anvil instance, including deployed contracts, artifacts, and usage instructions
* [deploy-environment.md](https://github.com/xmtp/smart-contracts/pull/39/files#diff-1746f806aa19ef2dc9fb66d6bd6733b86473129785133149785ed347196dcdda) has been added as a placeholder file

#### 📍Where to Start
Begin reviewing the main documentation file [xmtp-anvil-container-image.md](https://github.com/xmtp/smart-contracts/pull/39/files#diff-4ce98f9659c1cf19c1e96d45487b4281bc09b4b22214e894c9fdadc4b9ffd8ac) which contains the core content describing the Anvil container image setup and usage.

----

_[Macroscope](https://app.macroscope.com) summarized c28ab2f._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced comprehensive documentation for a new container image that provides a stable environment for local development and testing.
  - Detailed instructions on how to pull the image using Docker and similar container runtimes.
  - Provided guidelines on integrating the image into container build processes and on generating testing state artifacts for smooth local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->