### PR TITLE
Deployments v0.3.0

### DIFF
--- a/deployments/xmtp_testnet-staging_v0.3.0/CREATE3Factory.json
+++ b/deployments/xmtp_testnet-staging_v0.3.0/CREATE3Factory.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0xEC997ab30209D5044F2Bca00db4De5526B13177A"
+  },
+  "constructorArgs": "",
+  "deploymentBlock": 48595
+}

--- a/deployments/xmtp_testnet-staging_v0.3.0/GroupMessageBroadcaster.json
+++ b/deployments/xmtp_testnet-staging_v0.3.0/GroupMessageBroadcaster.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0x2697c14E933E44b7E08D78f63e9BB53EA48A97A4",
+    "proxy": "0xE845303a21B2132156a486A4017d3Ee8268536EC",
+    "proxyAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48596,
+  "latestUpgradeBlock": 48596
+}

--- a/deployments/xmtp_testnet-staging_v0.3.0/IdentityUpdateBroadcaster.json
+++ b/deployments/xmtp_testnet-staging_v0.3.0/IdentityUpdateBroadcaster.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0x467a071e7A3e25DE293aa568357cfcE6DD6866f2",
+    "proxy": "0x6756F4ACc41dEffC342459fE8FA44Fdf595c9f97",
+    "proxyAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48598,
+  "latestUpgradeBlock": 48598
+}

--- a/deployments/xmtp_testnet-staging_v0.3.0/NodeRegistry.json
+++ b/deployments/xmtp_testnet-staging_v0.3.0/NodeRegistry.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0x2b3eBB044b9Ff78923192C01D62DABcC813f9261"
+  },
+  "constructorArgs": {
+    "initialAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48600
+}

--- a/deployments/xmtp_testnet-staging_v0.3.0/RateRegistry.json
+++ b/deployments/xmtp_testnet-staging_v0.3.0/RateRegistry.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0x7aB373c6Cf6172Dc4A6A3C257bD22D4C3A4A725A",
+    "proxy": "0xa018EE7256994E49CE544b83E422F5f6f8d93f8A",
+    "proxyAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48601,
+  "latestUpgradeBlock": 48601
+}

--- a/deployments/xmtp_testnet-staging_v0.3.0/environment.json
+++ b/deployments/xmtp_testnet-staging_v0.3.0/environment.json
@@ -1,0 +1,7 @@
+{
+  "create3_factory_address": "0xEC997ab30209D5044F2Bca00db4De5526B13177A",
+  "rate_registry_address": "0xa018EE7256994E49CE544b83E422F5f6f8d93f8A",
+  "message_group_broadcaster_address": "0xE845303a21B2132156a486A4017d3Ee8268536EC",
+  "identity_update_broadcaster_address": "0x6756F4ACc41dEffC342459fE8FA44Fdf595c9f97",
+  "node_registry_address": "0x2b3eBB044b9Ff78923192C01D62DABcC813f9261"
+}

--- a/deployments/xmtp_testnet_v0.3.0/CREATE3Factory.json
+++ b/deployments/xmtp_testnet_v0.3.0/CREATE3Factory.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0x37CbfF93EC9330D245F177f52cADffa3C55D52e9"
+  },
+  "constructorArgs": "",
+  "deploymentBlock": 48609
+}

--- a/deployments/xmtp_testnet_v0.3.0/GroupMessageBroadcaster.json
+++ b/deployments/xmtp_testnet_v0.3.0/GroupMessageBroadcaster.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0xB0C142e9C8211Cb3df422cDfEE1571C6AD0C69Da",
+    "proxy": "0xfbf14ec1c268e64B256D705BCB78fb924795Cb81",
+    "proxyAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48610,
+  "latestUpgradeBlock": 48610
+}

--- a/deployments/xmtp_testnet_v0.3.0/IdentityUpdateBroadcaster.json
+++ b/deployments/xmtp_testnet_v0.3.0/IdentityUpdateBroadcaster.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0xfbF100eb884dd51b1d747a26441DF29B6A074fA4",
+    "proxy": "0xfb62Bd1B340479568F9231972B69B3Fc536a2958",
+    "proxyAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48611,
+  "latestUpgradeBlock": 48611
+}

--- a/deployments/xmtp_testnet_v0.3.0/NodeRegistry.json
+++ b/deployments/xmtp_testnet_v0.3.0/NodeRegistry.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0xD37ccd1DD051491f106f8b0A954BDc9AdA6FC731"
+  },
+  "constructorArgs": {
+    "initialAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48613
+}

--- a/deployments/xmtp_testnet_v0.3.0/RateRegistry.json
+++ b/deployments/xmtp_testnet_v0.3.0/RateRegistry.json
@@ -1,0 +1,10 @@
+{
+  "addresses": {
+    "deployer": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0",
+    "implementation": "0x400CCd22A49a6f080D71d968AF992fFe076F0E15",
+    "proxy": "0x0fc90488076c5CA9a9cF7481085cd05d7F7d3221",
+    "proxyAdmin": "0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0"
+  },
+  "deploymentBlock": 48614,
+  "latestUpgradeBlock": 48614
+}

--- a/deployments/xmtp_testnet_v0.3.0/environment.json
+++ b/deployments/xmtp_testnet_v0.3.0/environment.json
@@ -1,0 +1,7 @@
+{
+  "create3_factory_address": "0x37CbfF93EC9330D245F177f52cADffa3C55D52e9",
+  "rate_registry_address": "0x0fc90488076c5CA9a9cF7481085cd05d7F7d3221",
+  "message_group_broadcaster_address": "0xfbf14ec1c268e64B256D705BCB78fb924795Cb81",
+  "identity_update_broadcaster_address": "0xfb62Bd1B340479568F9231972B69B3Fc536a2958",
+  "node_registry_address": "0xD37ccd1DD051491f106f8b0A954BDc9AdA6FC731"
+}


### PR DESCRIPTION
### Deploy v0.3.0 contracts to XMTP testnet and testnet-staging environments
Adds deployment configuration files for v0.3.0 smart contracts across two environments:

* XMTP testnet-staging environment: Deployment files for `CREATE3Factory`, `GroupMessageBroadcaster`, `IdentityUpdateBroadcaster`, `NodeRegistry`, and `RateRegistry` contracts in [deployments/xmtp_testnet-staging_v0.3.0/](https://github.com/xmtp/smart-contracts/pull/42/files#diff-8da8a0f54122eb3990645b8d13a4140534d590732b575318f01387f91c334ab6)
* XMTP testnet environment: Deployment files for the same contracts in [deployments/xmtp_testnet_v0.3.0/](https://github.com/xmtp/smart-contracts/pull/42/files#diff-bf7e44b2d5409e00910ba49d5de0d8f467f3ce26b5e4854556b51ce3bf51bc16)

Each environment includes an `environment.json` file that consolidates all contract addresses for easy reference.

#### 📍Where to Start
Start with the environment summary files: [deployments/xmtp_testnet-staging_v0.3.0/environment.json](https://github.com/xmtp/smart-contracts/pull/42/files#diff-94fc0a98b303299a0d620b7e413db42e9118061995b5d5aef809393d98861e28) and [deployments/xmtp_testnet_v0.3.0/environment.json](https://github.com/xmtp/smart-contracts/pull/42/files#diff-d2f3106e58421ada582f60921ba561ba302b09f71a00cbf19e79095cb2e75bc7) which provide an overview of all deployed contract addresses.

----

_[Macroscope](https://app.macroscope.com) summarized ef8c434._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a suite of new deployment configuration files to support multiple network environments.
  - Enhanced smart contract deployment management by providing essential settings, including key addresses and upgrade tracking.
  - Standardized environment parameters to streamline and ensure consistent contract deployments across different networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->