### PR TITLE
feat: PayerReportManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint-staged": "lint-staged",
         "prettier": "prettier --write 'script/**/*.sol' 'src/**/*.sol' 'test/**/*.sol'",
         "prettier-check": "prettier --check 'script/**/*.sol' 'src/**/*.sol' 'test/**/*.sol'",
-        "slither": "forge build --build-info --skip '*/test/**' --skip '*/script/**' --force && slither --sarif output.sarif --compile-force-framework foundry --ignore-compile --config-file slither.config.json --fail-high .",
+        "slither": "rm -rf output.sarif && forge build --build-info --skip '*/test/**' --skip '*/script/**' --force && slither --sarif output.sarif --compile-force-framework foundry --ignore-compile --config-file slither.config.json --fail-high .",
         "solhint": "solhint -f stylish 'src/**/*.sol'",
         "solhint-fix": "solhint --fix 'src/**/*.sol'",
         "test": "forge test"

--- a/src/abstract/ERC5267.sol
+++ b/src/abstract/ERC5267.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IERC5267 } from "./interfaces/IERC5267.sol";
+
+import { ERC712 } from "./ERC712.sol";
+
+/**
+ * @title An abstract implementation of EIP-5267 for domain retrieval and typed structured data hashing and signing.
+ */
+abstract contract ERC5267 is IERC5267, ERC712 {
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Constructs the contract.
+     */
+    constructor() ERC712() {}
+
+    /* ============ Initialization ============ */
+
+    function _initializeERC5267() internal {
+        _initializeERC712();
+    }
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @inheritdoc IERC5267
+    function eip712Domain()
+        external
+        view
+        returns (
+            bytes1 fields_,
+            string memory name_,
+            string memory version_,
+            uint256 chainId_,
+            address verifyingContract_,
+            bytes32 salt_,
+            uint256[] memory extensions_
+        )
+    {
+        return (
+            hex"0f", // 01111 (salt is not used in the domain separator)
+            _name(),
+            _version(),
+            block.chainid,
+            address(this),
+            bytes32(0),
+            new uint256[](0)
+        );
+    }
+}

--- a/src/abstract/ERC712.sol
+++ b/src/abstract/ERC712.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IERC712 } from "./interfaces/IERC712.sol";
+
+/**
+ * @title An abstract implementation of EIP-712 for typed structured data hashing and signing.
+ */
+abstract contract ERC712 is IERC712 {
+    /* ============ Variables ============ */
+
+    /// @dev keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+    bytes32 internal constant _EIP712_DOMAIN_HASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+    /// @dev Initial Chain ID set at deployment.
+    uint256 internal immutable _initialChainId;
+
+    /* ============ UUPS Storage ============ */
+
+    /**
+     * @custom:storage-location erc7201:xmtp.storage.ERC712
+     * @notice The UUPS storage for the ERC712 contract.
+     * @param  initialDomainSeparator Initial EIP-712 domain separator set at intialization.
+     */
+    struct ERC712Storage {
+        bytes32 initialDomainSeparator;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("xmtp.storage.ERC712")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant _ERC712_STORAGE_LOCATION =
+        0xc7effa11ad597798220888e5d1ba4eeddcc8c2635d01dae8b9f958ac905c1100;
+
+    function _getERC712Storage() internal pure returns (ERC712Storage storage $) {
+        // slither-disable-next-line assembly
+        assembly {
+            $.slot := _ERC712_STORAGE_LOCATION
+        }
+    }
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Constructs the EIP-712 domain separator.
+     */
+    constructor() {
+        _initialChainId = block.chainid;
+    }
+
+    /* ============ Initialization ============ */
+
+    function _initializeERC712() internal {
+        _getERC712Storage().initialDomainSeparator = _getDomainSeparator();
+    }
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @inheritdoc IERC712
+    // slither-disable-next-line naming-convention
+    function DOMAIN_SEPARATOR() public view returns (bytes32 domainSeparator_) {
+        return block.chainid == _initialChainId ? _getERC712Storage().initialDomainSeparator : _getDomainSeparator();
+    }
+
+    /* ============ Internal View/Pure Functions ============ */
+
+    /**
+     * @dev    Computes the EIP-712 domain separator.
+     * @return domainSeparator_ The EIP-712 domain separator.
+     */
+    function _getDomainSeparator() internal view returns (bytes32 domainSeparator_) {
+        return
+            keccak256(
+                abi.encode(
+                    _EIP712_DOMAIN_HASH,
+                    keccak256(bytes(_name())),
+                    keccak256(bytes(_version())),
+                    block.chainid,
+                    address(this)
+                )
+            );
+    }
+
+    /**
+     * @dev    Returns the digest to be signed, via EIP-712, given an internal digest (i.e. hash struct).
+     * @param  internalDigest_ The internal digest.
+     * @return digest_         The digest to be signed.
+     */
+    function _getDigest(bytes32 internalDigest_) internal view returns (bytes32 digest_) {
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), internalDigest_));
+    }
+
+    /**
+     * @dev The name of the contract.
+     */
+    function _name() internal view virtual returns (string memory name_);
+
+    /**
+     * @dev The version of the contract.
+     */
+    function _version() internal view virtual returns (string memory version_);
+}

--- a/src/abstract/interfaces/IERC5267.sol
+++ b/src/abstract/interfaces/IERC5267.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IERC712 } from "./IERC712.sol";
+
+/**
+ * @title EIP-5267 extended from EIP-712.
+ * @dev   The interface as defined by EIP-5267: https://eips.ethereum.org/EIPS/eip-5267
+ */
+interface IERC5267 is IERC712 {
+    /* ============ Events ============ */
+
+    /// @notice MAY be emitted to signal that the domain could have changed.
+    event EIP712DomainChanged();
+
+    /* ============ View/Pure Functions ============ */
+
+    /**
+     * @notice Returns the fields and values that describe the domain separator used by this contract for EIP-712.
+     * @return fields_            A bit map where bit i is set to 1 if and only if domain field i is present
+     *                            (0 ≤ i ≤ 4). Bits are read from least significant to most significant, and fields are
+     *                            indexed in the order that is specified by EIP-712, identical to the order in which
+     *                            they are listed (i.e. name, version, chainId, verifyingContract, and salt).
+     * @return name_              The user readable name of signing domain.
+     * @return version_           The current major version of the signing domain.
+     * @return chainId_           The EIP-155 chain id.
+     * @return verifyingContract_ The address of the contract that will verify the signature.
+     * @return salt_              A disambiguating salt for the protocol.
+     * @return extensions_        A list of EIP numbers, each of which MUST refer to an EIP that extends EIP-712 with
+     *                              new domain fields, along with a method to obtain the value for those fields, and
+     *                              potentially conditions for inclusion. The value of fields does not affect their
+     *                              inclusion.
+     */
+    function eip712Domain()
+        external
+        view
+        returns (
+            bytes1 fields_,
+            string memory name_,
+            string memory version_,
+            uint256 chainId_,
+            address verifyingContract_,
+            bytes32 salt_,
+            uint256[] memory extensions_
+        );
+}

--- a/src/abstract/interfaces/IERC712.sol
+++ b/src/abstract/interfaces/IERC712.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title Typed structured data hashing and signing via EIP-712.
+ * @dev   The interface as defined by EIP-712: https://eips.ethereum.org/EIPS/eip-712
+ */
+interface IERC712 {
+    /* ============ View/Pure Functions ============ */
+
+    /// @notice Returns the EIP712 domain separator used in the encoding of a signed digest.
+    // slither-disable-next-line naming-convention
+    function DOMAIN_SEPARATOR() external view returns (bytes32 domainSeparator_);
+}

--- a/src/settlement-chain/PayerRegistry.sol
+++ b/src/settlement-chain/PayerRegistry.sol
@@ -183,19 +183,20 @@ contract PayerRegistry is IPayerRegistry, Migratable, Initializable {
     }
 
     /// @inheritdoc IPayerRegistry
-    function settleUsage(address[] calldata payers_, uint96[] calldata fees_) external onlySettler whenNotPaused {
-        require(payers_.length == fees_.length, ArrayLengthMismatch());
-
+    function settleUsage(
+        PayerFee[] calldata payerFees_
+    ) external onlySettler whenNotPaused returns (uint96 feesSettled_) {
         PayerRegistryStorage storage $ = _getPayerRegistryStorage();
         int104 totalDeposits_ = $.totalDeposits;
         uint96 totalDebt_ = $.totalDebt;
 
-        for (uint256 index_; index_ < payers_.length; ++index_) {
-            address payer_ = payers_[index_];
-            uint96 fee_ = fees_[index_];
+        for (uint256 index_; index_ < payerFees_.length; ++index_) {
+            address payer_ = payerFees_[index_].payer;
+            uint96 fee_ = payerFees_[index_].fee;
 
             emit UsageSettled(payer_, fee_);
 
+            feesSettled_ += fee_;
             totalDeposits_ -= _toInt104(fee_);
             totalDebt_ += _decreaseBalance(payer_, fee_);
         }

--- a/src/settlement-chain/interfaces/External.sol
+++ b/src/settlement-chain/interfaces/External.sol
@@ -89,3 +89,28 @@ interface IParameterRegistryLike {
 
     function get(bytes calldata key_) external view returns (bytes32 value_);
 }
+
+/**
+ * @title  Subset interface for a NodeRegistry.
+ * @notice This is the minimal interface needed by contracts within this subdirectory.
+ */
+interface INodeRegistryLike {
+    function canonicalNodesCount() external view returns (uint8 canonicalNodesCount_);
+
+    function getIsCanonicalNode(uint32 nodeId_) external view returns (bool isCanonicalNode_);
+
+    function getSigner(uint32 nodeId_) external view returns (address signer_);
+}
+
+/**
+ * @title  Subset interface for a PayerRegistry.
+ * @notice This is the minimal interface needed by contracts within this subdirectory.
+ */
+interface IPayerRegistryLike {
+    struct PayerFee {
+        address payer;
+        uint96 fee;
+    }
+
+    function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
+}

--- a/src/settlement-chain/interfaces/IPayerRegistry.sol
+++ b/src/settlement-chain/interfaces/IPayerRegistry.sol
@@ -26,6 +26,16 @@ interface IPayerRegistry is IMigratable {
         // 24 bits remaining in first slot
     }
 
+    /**
+     * @notice Represents a payer and their fee.
+     * @param  payer The address a payer.
+     * @param  fee   The fee to settle for the payer.
+     */
+    struct PayerFee {
+        address payer;
+        uint96 fee;
+    }
+
     /* ============ Events ============ */
 
     /**
@@ -156,9 +166,6 @@ interface IPayerRegistry is IMigratable {
      */
     error WithdrawalNotReady(uint32 timestamp, uint32 withdrawableTimestamp);
 
-    /// @notice Thrown when the lengths or array arguments do not match.
-    error ArrayLengthMismatch();
-
     /// @notice Thrown when trying to finalize a withdrawal while in debt.
     error PayerInDebt();
 
@@ -212,10 +219,10 @@ interface IPayerRegistry is IMigratable {
 
     /**
      * @notice Settles the usage fees for a list of payers.
-     * @param  payers_ The addresses of the payers.
-     * @param  fees_   The fees to settle for each payer.
+     * @param  payerFees_   An array of structs containing the payer and the fee to settle.
+     * @return feesSettled_ The total amount of fees settled.
      */
-    function settleUsage(address[] calldata payers_, uint96[] calldata fees_) external;
+    function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
 
     /**
      * @notice Sends the excess tokens in the contract to the fee distributor.

--- a/src/settlement-chain/interfaces/IPayerReportManager.sol
+++ b/src/settlement-chain/interfaces/IPayerReportManager.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IERC5267 } from "../../abstract/interfaces/IERC5267.sol";
+import { IMigratable } from "../../abstract/interfaces/IMigratable.sol";
+
+/**
+ * @title  The interface for the Payer Report Manager.
+ * @notice This interface exposes functionality for submitting and settling payer reports.
+ */
+interface IPayerReportManager is IMigratable, IERC5267 {
+    /* ============ Structs ============ */
+
+    /**
+     * @notice Represents a payer report.
+     * @param  startSequenceId  The start sequence ID.
+     * @param  endSequenceId    The end sequence ID.
+     * @param  feesSettled      The total fees already settled for this report.
+     * @param  offset           The next index in the merkle tree that has yet to be processed/settled.
+     * @param  isSettled        Whether the payer report is completely processed/settled.
+     * @param  payersMerkleRoot The payers merkle root.
+     * @param  nodeIds          The active node IDs during the reporting period.
+     */
+    struct PayerReport {
+        uint32 startSequenceId;
+        uint32 endSequenceId;
+        uint96 feesSettled;
+        uint32 offset;
+        bool isSettled;
+        bytes32 payersMerkleRoot;
+        uint32[] nodeIds;
+    }
+
+    /**
+     * @notice Represents a payer report signature.
+     * @param  nodeId    The node ID.
+     * @param  signature The signature by the node operator.
+     */
+    struct PayerReportSignature {
+        uint32 nodeId;
+        bytes signature;
+    }
+
+    /* ============ Events ============ */
+
+    /**
+     * @notice Emitted when a payer report is submitted.
+     * @param  originatorNodeId The originator node ID.
+     * @param  payerReportIndex The index of the newly stored report.
+     * @param  startSequenceId  The start sequence ID.
+     * @param  endSequenceId    The end sequence ID.
+     * @param  payersMerkleRoot The payers merkle root.
+     * @param  nodeIds          The active node IDs during the reporting period.
+     * @param  signingNodeIds   The node IDs of the signers of the payer report.
+     */
+    event PayerReportSubmitted(
+        uint32 indexed originatorNodeId,
+        uint256 indexed payerReportIndex,
+        uint32 startSequenceId,
+        uint32 indexed endSequenceId,
+        bytes32 payersMerkleRoot,
+        uint32[] nodeIds,
+        uint32[] signingNodeIds
+    );
+
+    /**
+     * @notice Emitted when a subset of a payer report is settled.
+     * @param  originatorNodeId The originator node ID.
+     * @param  payerReportIndex The payer report index.
+     * @param  count            The number of payer fees settled in this subset.
+     * @param  remaining        The number of payer fees remaining to be settled.
+     * @param  feesSettled      The amount of fees settled in this subset.
+     */
+    event PayerReportSubsetSettled(
+        uint32 indexed originatorNodeId,
+        uint256 indexed payerReportIndex,
+        uint32 count,
+        uint32 remaining,
+        uint96 feesSettled
+    );
+
+    /* ============ Custom Errors ============ */
+
+    /// @notice Error thrown when the parameter registry address is being set to zero (i.e. address(0)).
+    error ZeroParameterRegistry();
+
+    /// @notice Error thrown when the node registry address is being set to zero (i.e. address(0)).
+    error ZeroNodeRegistry();
+
+    /// @notice Error thrown when the payer registry address is being set to zero (i.e. address(0)).
+    error ZeroPayerRegistry();
+
+    /// @notice Error thrown when the start sequence ID is not the last end sequence ID.
+    error InvalidStartSequenceId(uint32 startSequenceId, uint32 lastSequenceId);
+
+    /// @notice Error thrown when the start and end sequence IDs are invalid.
+    error InvalidSequenceIds();
+
+    /// @notice Error thrown when the signing node IDs are not ordered and unique.
+    error UnorderedNodeIds();
+
+    /// @notice Error thrown when the number of valid signatures is insufficient.
+    error InsufficientSignatures(uint8 validSignatureCount, uint8 requiredSignatureCount);
+
+    /// @notice Error thrown when the payer report index is out of bounds.
+    error PayerReportIndexOutOfBounds();
+
+    /// @notice Error thrown when the payer report has already been entirely settled.
+    error PayerReportEntirelySettled();
+
+    /// @notice Error thrown when failing to settle usage via the payer registry.
+    error SettleUsageFailed(bytes returnData_);
+
+    /* ============ Initialization ============ */
+
+    /**
+     * @notice Initializes the contract.
+     */
+    function initialize() external;
+
+    /* ============ Interactive Functions ============ */
+
+    /**
+     * @notice Submits a payer report.
+     * @param  originatorNodeId_ The originator node ID.
+     * @param  startSequenceId_  The start sequence ID.
+     * @param  endSequenceId_    The end sequence ID.
+     * @param  payersMerkleRoot_ The payers merkle root.
+     * @param  nodeIds_          The active node IDs during the reporting period.
+     * @param  signatures_       The signature objects for the payer report.
+     * @return payerReportIndex_ The index of the payer report in the originator's payer report array.
+     */
+    function submit(
+        uint32 originatorNodeId_,
+        uint32 startSequenceId_,
+        uint32 endSequenceId_,
+        bytes32 payersMerkleRoot_,
+        uint32[] calldata nodeIds_,
+        PayerReportSignature[] calldata signatures_
+    ) external returns (uint256 payerReportIndex_);
+
+    /**
+     * @notice Settles a subset of a payer report.
+     * @param  originatorNodeId_ The originator node ID.
+     * @param  payerReportIndex_ The payer report index.
+     * @param  payerFees_        The sequential payer fees to settle.
+     * @param  proofElements_    The sequential merkle proof elements for the payer fees to settle.
+     */
+    function settle(
+        uint32 originatorNodeId_,
+        uint256 payerReportIndex_,
+        bytes[] calldata payerFees_,
+        bytes32[] calldata proofElements_
+    ) external;
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @notice The parameter registry key used to fetch the migrator.
+    function migratorParameterKey() external pure returns (bytes memory key_);
+
+    /// @notice The address of the parameter registry.
+    function parameterRegistry() external view returns (address parameterRegistry_);
+
+    /// @notice The address of the node registry.
+    function nodeRegistry() external view returns (address nodeRegistry_);
+
+    /// @notice The address of the payer registry.
+    function payerRegistry() external view returns (address payerRegistry_);
+
+    /**
+     * @notice Returns the payer reports for an originator node.
+     * @param  originatorNodeId_ The originator node ID.
+     * @return payerReports_     The array of payer reports.
+     */
+    function getPayerReports(uint32 originatorNodeId_) external view returns (PayerReport[] memory payerReports_);
+
+    /**
+     * @notice Returns a payer report.
+     * @param  originatorNodeId_ The originator node ID.
+     * @param  payerReportIndex_ The payer report index.
+     * @return payerReport_      The payer report.
+     */
+    function getPayerReport(
+        uint32 originatorNodeId_,
+        uint256 payerReportIndex_
+    ) external view returns (PayerReport memory payerReport_);
+
+    /**
+     * @notice Returns the EIP-712 digest for a payer report.
+     * @param  originatorNodeId_ The originator node ID.
+     * @param  startSequenceId_  The start sequence ID.
+     * @param  endSequenceId_    The end sequence ID.
+     * @param  payersMerkleRoot_ The payers merkle root.
+     * @param  nodeIds_          The active node IDs during the reporting period.
+     * @return digest_           The EIP-712 digest.
+     */
+    function getPayerReportDigest(
+        uint32 originatorNodeId_,
+        uint32 startSequenceId_,
+        uint32 endSequenceId_,
+        bytes32 payersMerkleRoot_,
+        uint32[] calldata nodeIds_
+    ) external view returns (bytes32 digest_);
+}

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -1,0 +1,1005 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Test } from "../../lib/forge-std/src/Test.sol";
+
+import { Initializable } from "../../lib/oz-upgradeable/contracts/proxy/utils/Initializable.sol";
+
+import { SequentialMerkleProofs } from "../../src/libraries/SequentialMerkleProofs.sol";
+
+import { IERC1967 } from "../../src/abstract/interfaces/IERC1967.sol";
+import { IMigratable } from "../../src/abstract/interfaces/IMigratable.sol";
+import { IPayerReportManager } from "../../src/settlement-chain/interfaces/IPayerReportManager.sol";
+
+import { Proxy } from "../../src/any-chain/Proxy.sol";
+
+import { PayerReportManagerHarness } from "../utils/Harnesses.sol";
+
+import {
+    MockParameterRegistry,
+    MockNodeRegistry,
+    MockPayerRegistry,
+    MockMigrator,
+    MockFailingMigrator
+} from "../utils/Mocks.sol";
+
+import { Utils } from "../utils/Utils.sol";
+
+contract PayerReportManagerTests is Test, Utils {
+    bytes32 internal constant _EIP712_DOMAIN_HASH =
+        keccak256(
+            abi.encodePacked("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+        );
+
+    bytes internal constant _MIGRATOR_KEY = "xmtp.payerReportManager.migrator";
+
+    PayerReportManagerHarness internal _manager;
+
+    address internal _implementation;
+    address internal _parameterRegistry;
+    address internal _nodeRegistry;
+    address internal _payerRegistry;
+
+    address internal _signer1;
+    uint256 internal _signer1Pk;
+    address internal _signer2;
+    uint256 internal _signer2Pk;
+    address internal _signer3;
+    uint256 internal _signer3Pk;
+    address internal _signer4;
+    uint256 internal _signer4Pk;
+
+    function setUp() external {
+        (_signer1, _signer1Pk) = makeAddrAndKey("signer1");
+        (_signer2, _signer2Pk) = makeAddrAndKey("signer2");
+        (_signer3, _signer3Pk) = makeAddrAndKey("signer3");
+        (_signer4, _signer4Pk) = makeAddrAndKey("signer4");
+
+        _parameterRegistry = address(new MockParameterRegistry());
+        _nodeRegistry = address(new MockNodeRegistry());
+        _payerRegistry = address(new MockPayerRegistry());
+
+        _implementation = address(new PayerReportManagerHarness(_parameterRegistry, _nodeRegistry, _payerRegistry));
+
+        _manager = PayerReportManagerHarness(address(new Proxy(_implementation)));
+
+        _manager.initialize();
+    }
+
+    /* ============ constructor ============ */
+
+    function test_constructor_zeroParameterRegistry() external {
+        vm.expectRevert(IPayerReportManager.ZeroParameterRegistry.selector);
+
+        new PayerReportManagerHarness(address(0), address(0), address(0));
+    }
+
+    function test_constructor_zeroNodeRegistry() external {
+        vm.expectRevert(IPayerReportManager.ZeroNodeRegistry.selector);
+
+        new PayerReportManagerHarness(_parameterRegistry, address(0), address(0));
+    }
+
+    function test_constructor_zeroPayerRegistry() external {
+        vm.expectRevert(IPayerReportManager.ZeroPayerRegistry.selector);
+
+        new PayerReportManagerHarness(_parameterRegistry, _nodeRegistry, address(0));
+    }
+
+    /* ============ initial state ============ */
+
+    function test_initialState() external view {
+        assertEq(_getImplementationFromSlot(address(_manager)), _implementation);
+        assertEq(_manager.implementation(), _implementation);
+        assertEq(_manager.parameterRegistry(), _parameterRegistry);
+        assertEq(_manager.nodeRegistry(), _nodeRegistry);
+        assertEq(_manager.payerRegistry(), _payerRegistry);
+        assertEq(_manager.migratorParameterKey(), _MIGRATOR_KEY);
+    }
+
+    /* ============ initializer ============ */
+
+    function test_initialize_reinitialization() external {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        _manager.initialize();
+    }
+
+    /* ============ submit ============ */
+
+    function test_submit_invalidStartSequenceId() external {
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 10,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.expectRevert(abi.encodeWithSelector(IPayerReportManager.InvalidStartSequenceId.selector, 11, 10));
+        _manager.submit({
+            originatorNodeId_: 0,
+            startSequenceId_: 11,
+            endSequenceId_: 11,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: new IPayerReportManager.PayerReportSignature[](0)
+        });
+    }
+
+    function test_submit_invalidSequenceIds() external {
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 10,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.expectRevert(IPayerReportManager.InvalidSequenceIds.selector);
+        _manager.submit({
+            originatorNodeId_: 0,
+            startSequenceId_: 10,
+            endSequenceId_: 9,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: new IPayerReportManager.PayerReportSignature[](0)
+        });
+    }
+
+    function test_submit_unorderedNodeIds() external {
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            2
+        );
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({ nodeId: 1, signature: "" });
+        signatures_[1] = IPayerReportManager.PayerReportSignature({ nodeId: 0, signature: "" });
+
+        vm.expectRevert(IPayerReportManager.UnorderedNodeIds.selector);
+        _manager.submit({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 1,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+    }
+
+    function test_submit_insufficientSignatures() external {
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            1
+        );
+
+        bytes memory signature_ = _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer1Pk);
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({ nodeId: 1, signature: signature_ });
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(3));
+
+        vm.expectRevert(abi.encodeWithSelector(IPayerReportManager.InsufficientSignatures.selector, 1, 2));
+        _manager.submit({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+    }
+
+    function test_submit_zeroPayersMerkleRoot() external {
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 1,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0)
+        });
+
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            3
+        );
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({
+            nodeId: 1,
+            signature: _getPayerReportSignature(0, 1, 2, bytes32(0), new uint32[](0), _signer1Pk)
+        });
+
+        signatures_[1] = IPayerReportManager.PayerReportSignature({
+            nodeId: 2,
+            signature: _getPayerReportSignature(0, 1, 2, bytes32(0), new uint32[](0), _signer2Pk)
+        });
+
+        signatures_[2] = IPayerReportManager.PayerReportSignature({
+            nodeId: 3,
+            signature: _getPayerReportSignature(0, 1, 2, bytes32(0), new uint32[](0), _signer3Pk)
+        });
+
+        uint32[] memory validSigningNodeIds_ = new uint32[](2);
+
+        validSigningNodeIds_[0] = 1;
+        validSigningNodeIds_[1] = 2;
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 2), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 2), abi.encode(_signer2));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 3), abi.encode(false));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(3));
+
+        vm.expectEmit(address(_manager));
+        emit IPayerReportManager.PayerReportSubmitted({
+            originatorNodeId: 0,
+            payerReportIndex: 1,
+            startSequenceId: 1,
+            endSequenceId: 2,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: new uint32[](0),
+            signingNodeIds: validSigningNodeIds_
+        });
+
+        vm.expectEmit(address(_manager));
+        emit IPayerReportManager.PayerReportSubsetSettled(0, 1, 0, 0, 0);
+
+        uint256 payerReportIndex_ = _manager.submit({
+            originatorNodeId_: 0,
+            startSequenceId_: 1,
+            endSequenceId_: 2,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+
+        assertEq(payerReportIndex_, 1);
+
+        IPayerReportManager.PayerReport memory payerReport_ = _manager.getPayerReport(0, 1);
+
+        assertEq(payerReport_.startSequenceId, 1);
+        assertEq(payerReport_.endSequenceId, 2);
+        assertEq(payerReport_.feesSettled, 0);
+        assertEq(payerReport_.offset, 0);
+        assertTrue(payerReport_.isSettled);
+        assertEq(payerReport_.payersMerkleRoot, bytes32(0));
+        assertEq(payerReport_.nodeIds.length, 0);
+    }
+
+    function test_submit() external {
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 1,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0)
+        });
+
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            3
+        );
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({
+            nodeId: 1,
+            signature: _getPayerReportSignature(0, 1, 2, bytes32(uint256(1)), new uint32[](0), _signer1Pk)
+        });
+
+        signatures_[1] = IPayerReportManager.PayerReportSignature({
+            nodeId: 2,
+            signature: _getPayerReportSignature(0, 1, 2, bytes32(uint256(1)), new uint32[](0), _signer2Pk)
+        });
+
+        signatures_[2] = IPayerReportManager.PayerReportSignature({
+            nodeId: 3,
+            signature: _getPayerReportSignature(0, 1, 2, bytes32(uint256(1)), new uint32[](0), _signer3Pk)
+        });
+
+        uint32[] memory validSigningNodeIds_ = new uint32[](2);
+
+        validSigningNodeIds_[0] = 1;
+        validSigningNodeIds_[1] = 2;
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 2), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 2), abi.encode(_signer2));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 3), abi.encode(false));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(3));
+
+        vm.expectEmit(address(_manager));
+        emit IPayerReportManager.PayerReportSubmitted({
+            originatorNodeId: 0,
+            payerReportIndex: 1,
+            startSequenceId: 1,
+            endSequenceId: 2,
+            payersMerkleRoot: bytes32(uint256(1)),
+            nodeIds: new uint32[](0),
+            signingNodeIds: validSigningNodeIds_
+        });
+
+        uint256 payerReportIndex_ = _manager.submit({
+            originatorNodeId_: 0,
+            startSequenceId_: 1,
+            endSequenceId_: 2,
+            payersMerkleRoot_: bytes32(uint256(1)),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+
+        assertEq(payerReportIndex_, 1);
+
+        IPayerReportManager.PayerReport memory payerReport_ = _manager.getPayerReport(0, 1);
+
+        assertEq(payerReport_.startSequenceId, 1);
+        assertEq(payerReport_.endSequenceId, 2);
+        assertEq(payerReport_.feesSettled, 0);
+        assertEq(payerReport_.offset, 0);
+        assertFalse(payerReport_.isSettled);
+        assertEq(payerReport_.payersMerkleRoot, bytes32(uint256(1)));
+        assertEq(payerReport_.nodeIds.length, 0);
+    }
+
+    /* ============ settle ============ */
+
+    function test_settle_payerReportIndexOutOfBounds() external {
+        vm.expectRevert(IPayerReportManager.PayerReportIndexOutOfBounds.selector);
+        _manager.settle(0, 0, new bytes[](0), new bytes32[](0));
+    }
+
+    function test_settle_payerReportEntirelySettled() external {
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: true,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.expectRevert(IPayerReportManager.PayerReportEntirelySettled.selector);
+        _manager.settle(0, 0, new bytes[](0), new bytes32[](0));
+    }
+
+    function test_settle_invalidProof() external {
+        // This is the root for the payer fees: (1, 100), (2, 200), (3, 300), (4, 400), (5, 500), (6, 600).
+        bytes32 payersMerkleRoot_ = 0xf3051bbf3818e5393ac18edd8ba285e62f35fe01748a8acc900eca813a6b364e;
+
+        bytes[] memory payerFees_ = new bytes[](3);
+        payerFees_[0] = abi.encode(address(1), uint96(100));
+        payerFees_[1] = abi.encode(address(2), uint96(200));
+        payerFees_[2] = abi.encode(address(3), uint96(300));
+
+        bytes32[] memory proofElements_ = new bytes32[](3);
+
+        // Incorrect leaf count as first proof element.
+        proofElements_[0] = bytes32(uint256(0x0000000000000000000000000000000000000000000000000000000000000005));
+        proofElements_[1] = bytes32(0xbf3990232dba4985267c2b0c64d09165457aa9bc02292fff8416821335f719ad);
+        proofElements_[2] = bytes32(0x179a5ab6250bc7b598e955bb7a59ed2b26171140d0c9ecbdb5e2ee15a529dfc5);
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: payersMerkleRoot_,
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _manager.settle(0, 0, payerFees_, proofElements_);
+    }
+
+    function test_settle_settleUsageFailed() external {
+        // This is the root for the payer fees: (1, 100), (2, 200), (3, 300), (4, 400), (5, 500), (6, 600).
+        bytes32 payersMerkleRoot_ = 0xf3051bbf3818e5393ac18edd8ba285e62f35fe01748a8acc900eca813a6b364e;
+
+        bytes[] memory payerFees_ = new bytes[](3);
+        payerFees_[0] = abi.encode(address(1), uint96(100));
+        payerFees_[1] = abi.encode(address(2), uint96(200));
+        payerFees_[2] = abi.encode(address(3), uint96(300));
+
+        bytes32[] memory proofElements_ = new bytes32[](3);
+        proofElements_[0] = bytes32(uint256(0x0000000000000000000000000000000000000000000000000000000000000006));
+        proofElements_[1] = bytes32(0xbf3990232dba4985267c2b0c64d09165457aa9bc02292fff8416821335f719ad);
+        proofElements_[2] = bytes32(0x179a5ab6250bc7b598e955bb7a59ed2b26171140d0c9ecbdb5e2ee15a529dfc5);
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: payersMerkleRoot_,
+            nodeIds_: new uint32[](0)
+        });
+
+        // TODO: `expectCallAndRevert`.
+        vm.mockCallRevert(
+            _payerRegistry,
+            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            "Test Failure"
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IPayerReportManager.SettleUsageFailed.selector, "Test Failure"));
+        _manager.settle(0, 0, payerFees_, proofElements_);
+    }
+
+    function test_settle_firstHalf() external {
+        // This is the root for the payer fees: (1, 100), (2, 200), (3, 300), (4, 400), (5, 500), (6, 600).
+        bytes32 payersMerkleRoot_ = 0xf3051bbf3818e5393ac18edd8ba285e62f35fe01748a8acc900eca813a6b364e;
+
+        bytes[] memory payerFees_ = new bytes[](3);
+        payerFees_[0] = abi.encode(address(1), uint96(100));
+        payerFees_[1] = abi.encode(address(2), uint96(200));
+        payerFees_[2] = abi.encode(address(3), uint96(300));
+
+        bytes32[] memory proofElements_ = new bytes32[](3);
+        proofElements_[0] = bytes32(uint256(0x0000000000000000000000000000000000000000000000000000000000000006));
+        proofElements_[1] = bytes32(0xbf3990232dba4985267c2b0c64d09165457aa9bc02292fff8416821335f719ad);
+        proofElements_[2] = bytes32(0x179a5ab6250bc7b598e955bb7a59ed2b26171140d0c9ecbdb5e2ee15a529dfc5);
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: payersMerkleRoot_,
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.mockCall(
+            _payerRegistry,
+            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encode(uint96(600))
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IPayerReportManager.PayerReportSubsetSettled(0, 0, 3, 3, 600);
+
+        _manager.settle(0, 0, payerFees_, proofElements_);
+
+        assertEq(_manager.getPayerReport(0, 0).feesSettled, 600);
+        assertEq(_manager.getPayerReport(0, 0).offset, 3);
+    }
+
+    function test_settle_secondHalf() external {
+        // This is the root for the payer fees: (1, 100), (2, 200), (3, 300), (4, 400), (5, 500), (6, 600).
+        bytes32 payersMerkleRoot_ = 0xf3051bbf3818e5393ac18edd8ba285e62f35fe01748a8acc900eca813a6b364e;
+
+        bytes[] memory payerFees_ = new bytes[](3);
+        payerFees_[0] = abi.encode(address(4), uint96(400));
+        payerFees_[1] = abi.encode(address(5), uint96(500));
+        payerFees_[2] = abi.encode(address(6), uint96(600));
+
+        bytes32[] memory proofElements_ = new bytes32[](3);
+        proofElements_[0] = bytes32(uint256(0x0000000000000000000000000000000000000000000000000000000000000006));
+        proofElements_[1] = bytes32(0xe1fd91200025ec7e94c96c4e035820e7f510e94f479b07caf2791ed8991d80ca);
+        proofElements_[2] = bytes32(0x81c8c090425d4a46672a976619a2dd2fce8b9b0fea5e01d1fb32e78bff1681d0);
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            feesSettled_: 600,
+            offset_: 3,
+            isSettled_: false,
+            payersMerkleRoot_: payersMerkleRoot_,
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.mockCall(
+            _payerRegistry,
+            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encode(uint96(1_500))
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IPayerReportManager.PayerReportSubsetSettled(0, 0, 3, 0, 1_500);
+
+        _manager.settle(0, 0, payerFees_, proofElements_);
+
+        assertEq(_manager.getPayerReport(0, 0).feesSettled, 600 + 1_500);
+        assertEq(_manager.getPayerReport(0, 0).offset, 6);
+        assertTrue(_manager.getPayerReport(0, 0).isSettled);
+    }
+
+    function test_settle_oneShot() external {
+        // This is the root for the payer fees: (1, 100), (2, 200), (3, 300), (4, 400), (5, 500), (6, 600).
+        bytes32 payersMerkleRoot_ = 0xf3051bbf3818e5393ac18edd8ba285e62f35fe01748a8acc900eca813a6b364e;
+
+        bytes[] memory payerFees_ = new bytes[](6);
+        payerFees_[0] = abi.encode(address(1), uint96(100));
+        payerFees_[1] = abi.encode(address(2), uint96(200));
+        payerFees_[2] = abi.encode(address(3), uint96(300));
+        payerFees_[3] = abi.encode(address(4), uint96(400));
+        payerFees_[4] = abi.encode(address(5), uint96(500));
+        payerFees_[5] = abi.encode(address(6), uint96(600));
+
+        bytes32[] memory proofElements_ = new bytes32[](1);
+        proofElements_[0] = bytes32(uint256(0x0000000000000000000000000000000000000000000000000000000000000006));
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            feesSettled_: 0,
+            offset_: 0,
+            isSettled_: false,
+            payersMerkleRoot_: payersMerkleRoot_,
+            nodeIds_: new uint32[](0)
+        });
+
+        vm.mockCall(
+            _payerRegistry,
+            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encode(uint96(2_100))
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IPayerReportManager.PayerReportSubsetSettled(0, 0, 6, 0, 2_100);
+
+        _manager.settle(0, 0, payerFees_, proofElements_);
+
+        assertEq(_manager.getPayerReport(0, 0).feesSettled, 2_100);
+        assertEq(_manager.getPayerReport(0, 0).offset, 6);
+        assertTrue(_manager.getPayerReport(0, 0).isSettled);
+    }
+
+    /* ============ migrate ============ */
+
+    function test_migrate_zeroMigrator() external {
+        vm.expectRevert(IMigratable.ZeroMigrator.selector);
+        _manager.migrate();
+    }
+
+    function test_migrate_migrationFailed() external {
+        address migrator_ = address(new MockFailingMigrator());
+
+        _mockParameterRegistryCall(_MIGRATOR_KEY, migrator_);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMigratable.MigrationFailed.selector,
+                migrator_,
+                abi.encodeWithSelector(MockFailingMigrator.Failed.selector)
+            )
+        );
+
+        _manager.migrate();
+    }
+
+    function test_migrate_emptyCode() external {
+        _mockParameterRegistryCall(_MIGRATOR_KEY, address(1));
+
+        vm.expectRevert(abi.encodeWithSelector(IMigratable.EmptyCode.selector, address(1)));
+
+        _manager.migrate();
+    }
+
+    function test_migrate() external {
+        _manager.__pushPayerReport({
+            originatorNodeId_: 1,
+            startSequenceId_: 2,
+            endSequenceId_: 3,
+            feesSettled_: 4,
+            offset_: 5,
+            isSettled_: true,
+            payersMerkleRoot_: bytes32(uint256(6)),
+            nodeIds_: new uint32[](7)
+        });
+
+        address newImplementation_ = address(
+            new PayerReportManagerHarness(_parameterRegistry, _nodeRegistry, _payerRegistry)
+        );
+
+        address migrator_ = address(new MockMigrator(newImplementation_));
+
+        // TODO: `_expectAndMockParameterRegistryCall`.
+        _mockParameterRegistryCall(_MIGRATOR_KEY, migrator_);
+
+        vm.expectEmit(address(_manager));
+        emit IMigratable.Migrated(migrator_);
+
+        vm.expectEmit(address(_manager));
+        emit IERC1967.Upgraded(newImplementation_);
+
+        _manager.migrate();
+
+        assertEq(_getImplementationFromSlot(address(_manager)), newImplementation_);
+        assertEq(_manager.parameterRegistry(), _parameterRegistry);
+
+        IPayerReportManager.PayerReport[] memory payerReports_ = _manager.getPayerReports(1);
+
+        assertEq(payerReports_.length, 1);
+
+        assertEq(payerReports_[0].startSequenceId, 2);
+        assertEq(payerReports_[0].endSequenceId, 3);
+        assertEq(payerReports_[0].feesSettled, 4);
+        assertEq(payerReports_[0].offset, 5);
+        assertTrue(payerReports_[0].isSettled);
+        assertEq(payerReports_[0].payersMerkleRoot, bytes32(uint256(6)));
+        assertEq(payerReports_[0].nodeIds.length, 7);
+    }
+
+    /* ============ _verifySignatures ============ */
+
+    function test_internal_verifySignatures_unorderedNodeIds() external {
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            2
+        );
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({ nodeId: 1, signature: "" });
+        signatures_[1] = IPayerReportManager.PayerReportSignature({ nodeId: 0, signature: "" });
+
+        vm.expectRevert(IPayerReportManager.UnorderedNodeIds.selector);
+        _manager.__verifySignatures({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+    }
+
+    function test_internal_verifySignatures_insufficientSignatures() external {
+        vm.expectRevert(abi.encodeWithSelector(IPayerReportManager.InsufficientSignatures.selector, 0, 1));
+        _manager.__verifySignatures({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: new IPayerReportManager.PayerReportSignature[](0)
+        });
+    }
+
+    function test_internal_verifySignatures_lastInvalid() external {
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            3
+        );
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({
+            nodeId: 1,
+            signature: _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer1Pk)
+        });
+
+        signatures_[1] = IPayerReportManager.PayerReportSignature({
+            nodeId: 2,
+            signature: _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer2Pk)
+        });
+
+        signatures_[2] = IPayerReportManager.PayerReportSignature({
+            nodeId: 3,
+            signature: _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer3Pk)
+        });
+
+        uint32[] memory expectedValidSigningNodeIds_ = new uint32[](2);
+
+        expectedValidSigningNodeIds_[0] = 1;
+        expectedValidSigningNodeIds_[1] = 2;
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 2), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 2), abi.encode(_signer2));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 3), abi.encode(false));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(3));
+
+        uint32[] memory validSigningNodeIds_ = _manager.__verifySignatures({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+
+        assertEq(validSigningNodeIds_.length, 2);
+
+        assertEq(validSigningNodeIds_[0], 1);
+        assertEq(validSigningNodeIds_[1], 2);
+    }
+
+    function test_internal_verifySignatures_middleInvalid() external {
+        IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
+            3
+        );
+
+        signatures_[0] = IPayerReportManager.PayerReportSignature({
+            nodeId: 1,
+            signature: _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer1Pk)
+        });
+
+        signatures_[1] = IPayerReportManager.PayerReportSignature({
+            nodeId: 2,
+            signature: _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer2Pk)
+        });
+
+        signatures_[2] = IPayerReportManager.PayerReportSignature({
+            nodeId: 3,
+            signature: _getPayerReportSignature(0, 0, 0, bytes32(0), new uint32[](0), _signer3Pk)
+        });
+
+        uint32[] memory expectedValidSigningNodeIds_ = new uint32[](2);
+
+        expectedValidSigningNodeIds_[0] = 1;
+        expectedValidSigningNodeIds_[1] = 3;
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 2), abi.encode(false));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 3), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 3), abi.encode(_signer3));
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(3));
+
+        uint32[] memory validSigningNodeIds_ = _manager.__verifySignatures({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            signatures_: signatures_
+        });
+
+        assertEq(validSigningNodeIds_.length, 2);
+
+        assertEq(validSigningNodeIds_[0], 1);
+        assertEq(validSigningNodeIds_[1], 3);
+    }
+
+    /* ============ _verifySignature ============ */
+
+    function test_internal_verifySignature_notCanonicalNode() external {
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(false));
+        assertFalse(_manager.__verifySignature(bytes32(0), 1, ""));
+    }
+
+    function test_internal_verifySignature_invalidSignature() external {
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        assertFalse(_manager.__verifySignature(bytes32(0), 1, ""));
+    }
+
+    function test_internal_verifySignature_notNodeOwner() external {
+        bytes memory signature_ = _getPayerReportSignature({
+            originatorNodeId_: 0,
+            startSequenceId_: 0,
+            endSequenceId_: 0,
+            payersMerkleRoot_: bytes32(0),
+            nodeIds_: new uint32[](0),
+            privateKey_: _signer1Pk
+        });
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+
+        assertFalse(_manager.__verifySignature(bytes32(0), 1, signature_));
+    }
+
+    function test_internal_verifySignature() external {
+        bytes memory signature_ = _getSignature(bytes32(0), _signer1Pk);
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getIsCanonicalNode(uint32)", 1), abi.encode(true));
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
+
+        assertTrue(_manager.__verifySignature(bytes32(0), 1, signature_));
+    }
+
+    /* ============ getPayerReportDigest ============ */
+
+    function test_getPayerReportDigest() external view {
+        assertEq(
+            _manager.getPayerReportDigest({
+                originatorNodeId_: 1,
+                startSequenceId_: 2,
+                endSequenceId_: 3,
+                payersMerkleRoot_: bytes32(uint256(4)),
+                nodeIds_: new uint32[](5)
+            }),
+            0x65e9298004b22b280cef382f32439d34255f8eb6245503d0d402a6186ffe9fdc
+        );
+
+        assertEq(
+            _manager.getPayerReportDigest({
+                originatorNodeId_: 10,
+                startSequenceId_: 20,
+                endSequenceId_: 30,
+                payersMerkleRoot_: bytes32(uint256(40)),
+                nodeIds_: new uint32[](50)
+            }),
+            0xa768e78486ac9abadd510980ff8b1ba18e61d40358b934c09d10474ad5b65903
+        );
+    }
+
+    /* ============ getPayerReports ============ */
+
+    function test_getPayerReports() external {
+        assertEq(_manager.getPayerReports(1).length, 0);
+
+        uint32[] memory nodeIds_ = new uint32[](7);
+
+        for (uint32 index_; index_ < nodeIds_.length; ++index_) {
+            nodeIds_[index_] = 10 + index_;
+        }
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 1,
+            startSequenceId_: 2,
+            endSequenceId_: 3,
+            feesSettled_: 4,
+            offset_: 5,
+            isSettled_: true,
+            payersMerkleRoot_: bytes32(uint256(6)),
+            nodeIds_: nodeIds_
+        });
+
+        IPayerReportManager.PayerReport[] memory payerReports_ = _manager.getPayerReports(1);
+
+        assertEq(payerReports_.length, 1);
+
+        assertEq(payerReports_[0].startSequenceId, 2);
+        assertEq(payerReports_[0].endSequenceId, 3);
+        assertEq(payerReports_[0].feesSettled, 4);
+        assertEq(payerReports_[0].offset, 5);
+        assertTrue(payerReports_[0].isSettled);
+        assertEq(payerReports_[0].payersMerkleRoot, bytes32(uint256(6)));
+        assertEq(payerReports_[0].nodeIds.length, 7);
+
+        for (uint32 index_; index_ < nodeIds_.length; ++index_) {
+            assertEq(payerReports_[0].nodeIds[index_], 10 + index_);
+        }
+    }
+
+    /* ============ getPayerReport ============ */
+
+    function test_getPayerReport() external {
+        uint32[] memory nodeIds_ = new uint32[](7);
+
+        for (uint32 index_; index_ < nodeIds_.length; ++index_) {
+            nodeIds_[index_] = 10 + index_;
+        }
+
+        _manager.__pushPayerReport({
+            originatorNodeId_: 1,
+            startSequenceId_: 2,
+            endSequenceId_: 3,
+            feesSettled_: 4,
+            offset_: 5,
+            isSettled_: true,
+            payersMerkleRoot_: bytes32(uint256(6)),
+            nodeIds_: nodeIds_
+        });
+
+        IPayerReportManager.PayerReport memory payerReport_ = _manager.getPayerReport(1, 0);
+
+        assertEq(payerReport_.startSequenceId, 2);
+        assertEq(payerReport_.endSequenceId, 3);
+        assertEq(payerReport_.feesSettled, 4);
+        assertEq(payerReport_.offset, 5);
+        assertTrue(payerReport_.isSettled);
+        assertEq(payerReport_.payersMerkleRoot, bytes32(uint256(6)));
+        assertEq(payerReport_.nodeIds.length, 7);
+
+        for (uint32 index_; index_ < nodeIds_.length; ++index_) {
+            assertEq(payerReport_.nodeIds[index_], 10 + index_);
+        }
+    }
+
+    /* ============ DOMAIN_SEPARATOR ============ */
+
+    function test_DOMAIN_SEPARATOR() external view {
+        assertEq(
+            _manager.DOMAIN_SEPARATOR(),
+            keccak256(
+                abi.encode(
+                    _EIP712_DOMAIN_HASH,
+                    keccak256(bytes("PayerReportManager")),
+                    keccak256(bytes("1")),
+                    block.chainid,
+                    address(_manager)
+                )
+            )
+        );
+    }
+
+    /* ============ eip712Domain ============ */
+
+    function test_eip712Domain() external view {
+        (
+            bytes1 fields_,
+            string memory name_,
+            string memory version_,
+            uint256 chainId_,
+            address verifyingContract_,
+            bytes32 salt_,
+            uint256[] memory extensions_
+        ) = _manager.eip712Domain();
+
+        assertEq(fields_, hex"0f");
+        assertEq(name_, "PayerReportManager");
+        assertEq(version_, "1");
+        assertEq(chainId_, block.chainid);
+        assertEq(verifyingContract_, address(_manager));
+        assertEq(salt_, bytes32(0));
+        assertEq(extensions_.length, 0);
+    }
+
+    /* ============ helper functions ============ */
+
+    function _mockParameterRegistryCall(bytes memory key_, address value_) internal {
+        _mockParameterRegistryCall(key_, bytes32(uint256(uint160(value_))));
+    }
+
+    function _mockParameterRegistryCall(bytes memory key_, bool value_) internal {
+        _mockParameterRegistryCall(key_, value_ ? bytes32(uint256(1)) : bytes32(uint256(0)));
+    }
+
+    function _mockParameterRegistryCall(bytes memory key_, uint256 value_) internal {
+        _mockParameterRegistryCall(key_, bytes32(value_));
+    }
+
+    function _mockParameterRegistryCall(bytes memory key_, bytes32 value_) internal {
+        vm.mockCall(_parameterRegistry, abi.encodeWithSignature("get(bytes)", key_), abi.encode(value_));
+    }
+
+    function _getImplementationFromSlot(address proxy_) internal view returns (address implementation_) {
+        // Retrieve the implementation address directly from the proxy storage.
+        return address(uint160(uint256(vm.load(proxy_, EIP1967_IMPLEMENTATION_SLOT))));
+    }
+
+    function _getPayerReportSignature(
+        uint32 originatorNodeId_,
+        uint32 startSequenceId_,
+        uint32 endSequenceId_,
+        bytes32 payersMerkleRoot_,
+        uint32[] memory nodeIds_,
+        uint256 privateKey_
+    ) internal view returns (bytes memory signature_) {
+        return
+            _getSignature(
+                _manager.getPayerReportDigest(
+                    originatorNodeId_,
+                    startSequenceId_,
+                    endSequenceId_,
+                    payersMerkleRoot_,
+                    nodeIds_
+                ),
+                privateKey_
+            );
+    }
+
+    function _getSignature(bytes32 digest_, uint256 privateKey_) internal pure returns (bytes memory signature_) {
+        (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(privateKey_, digest_);
+
+        return abi.encodePacked(r_, s_, v_);
+    }
+}

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -17,6 +17,7 @@ import { PayloadBroadcaster } from "../../src/abstract/PayloadBroadcaster.sol";
 import { RateRegistry } from "../../src/settlement-chain/RateRegistry.sol";
 import { SettlementChainGateway } from "../../src/settlement-chain/SettlementChainGateway.sol";
 import { SettlementChainParameterRegistry } from "../../src/settlement-chain/SettlementChainParameterRegistry.sol";
+import { PayerReportManager } from "../../src/settlement-chain/PayerReportManager.sol";
 
 contract PayloadBroadcasterHarness is PayloadBroadcaster {
     constructor(address parameterRegistry_) PayloadBroadcaster(parameterRegistry_) {}
@@ -404,5 +405,63 @@ contract SequentialMerkleProofsHarness {
         bytes[] calldata leaves_
     ) external pure returns (bytes32[] memory reversedLeaves_) {
         return SequentialMerkleProofs._getReversedLeafNodesFromLeaves(leaves_);
+    }
+}
+
+contract PayerReportManagerHarness is PayerReportManager {
+    constructor(
+        address parameterRegistry_,
+        address nodeRegistry_,
+        address payerRegistry_
+    ) PayerReportManager(parameterRegistry_, nodeRegistry_, payerRegistry_) {}
+
+    function __pushPayerReport(
+        uint32 originatorNodeId_,
+        uint32 startSequenceId_,
+        uint32 endSequenceId_,
+        uint96 feesSettled_,
+        uint32 offset_,
+        bool isSettled_,
+        bytes32 payersMerkleRoot_,
+        uint32[] calldata nodeIds_
+    ) external {
+        _getPayerReportManagerStorage().payerReportsByOriginator[originatorNodeId_].push(
+            PayerReport({
+                startSequenceId: startSequenceId_,
+                endSequenceId: endSequenceId_,
+                feesSettled: feesSettled_,
+                offset: offset_,
+                isSettled: isSettled_,
+                payersMerkleRoot: payersMerkleRoot_,
+                nodeIds: nodeIds_
+            })
+        );
+    }
+
+    function __verifySignatures(
+        uint32 originatorNodeId_,
+        uint32 startSequenceId_,
+        uint32 endSequenceId_,
+        bytes32 payersMerkleRoot_,
+        uint32[] calldata nodeIds_,
+        PayerReportSignature[] calldata signatures_
+    ) external view returns (uint32[] memory validSigningNodeIds_) {
+        return
+            _verifySignatures(
+                originatorNodeId_,
+                startSequenceId_,
+                endSequenceId_,
+                payersMerkleRoot_,
+                nodeIds_,
+                signatures_
+            );
+    }
+
+    function __verifySignature(
+        bytes32 digest_,
+        uint32 nodeId_,
+        bytes calldata signature_
+    ) external view returns (bool isValid_) {
+        return _verifySignature(digest_, nodeId_, signature_);
     }
 }

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -76,3 +76,22 @@ contract MockERC20Inbox {
         bytes calldata data_
     ) external returns (uint256 messageNumber_) {}
 }
+
+contract MockNodeRegistry {
+    uint8 public canonicalNodesCount;
+
+    function getIsCanonicalNode(uint32 nodeId_) external view returns (bool isCanonicalNode_) {
+        return true;
+    }
+
+    function getSigner(uint32 nodeId_) external view returns (address signer_) {}
+}
+
+contract MockPayerRegistry {
+    struct PayerFee {
+        address payer;
+        uint96 fee;
+    }
+
+    function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_) {}
+}


### PR DESCRIPTION
- added ERC712 and ERC5267 abstractions
- added `getLeafCount` to the `SequentialMerkleProofs` library to extract the leaf count from a proof, as it is needed to update the progress of settling a payer report
- added `PayerReportManager`
- `PayerRegistry.settleUsage` updated to return fees settled in the subset, as it will be needed for distribution progress tracking later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the Payer Report Manager contract, enabling secure submission and settlement of payer reports with multi-signature verification and Merkle proof support.
  - Added interfaces and contracts supporting EIP-712 and EIP-5267 domain separation for typed structured data signing.
  - Provided new interfaces for node and payer registries, supporting modular and upgradeable design.

- **Refactor**
  - Updated settlement functions to use a single array of payer-fee structs instead of separate arrays, simplifying usage and reducing input errors.

- **Tests**
  - Added comprehensive unit tests for the Payer Report Manager, including signature verification, settlement, migration, and upgradeability.
  - Introduced new test harnesses and mock contracts to facilitate robust testing of core features.

- **Chores**
  - Improved the Slither analysis script to ensure clean SARIF report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->