### PR TITLE
refactor: NodeRegistry

### DIFF
--- a/src/abstract/Migratable.sol
+++ b/src/abstract/Migratable.sol
@@ -33,6 +33,7 @@ abstract contract Migratable is IMigratable {
      * @param migrator_ The address of a migrator contract.
      * @dev   The migrator fallback code defines the entire migration process, and takes no user-defined arguments.
      */
+    // slither-disable-next-line controlled-delegatecall
     function _migrate(address migrator_) internal {
         require(migrator_ != address(0), ZeroMigrator());
 

--- a/src/libraries/SequentialMerkleProofs.sol
+++ b/src/libraries/SequentialMerkleProofs.sol
@@ -92,7 +92,7 @@ library SequentialMerkleProofs {
     }
 
     /**
-     * @notice Rounds a 632-bit unsigned integer up to the nearest power of 2.
+     * @notice Rounds a 32-bit unsigned integer up to the nearest power of 2.
      * @param  n_        The number to round up to the nearest power of 2.
      * @return powerOf2_ The nearest power of 2 to `n_`.
      * @dev    Literals are inlined as they are very specific to this algorithm/function, and actually improve

--- a/src/libraries/SequentialMerkleProofs.sol
+++ b/src/libraries/SequentialMerkleProofs.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title  Library for verifying sequential merkle proofs.
+ * @notice A sequential merkle proof is a proof that leaves appear sequentially in a merkle tree.
+ */
+library SequentialMerkleProofs {
+    /* ============ Constants ============ */
+
+    /// @notice The leaf prefix used to hash to a leaf.
+    bytes internal constant LEAF_PREFIX = bytes("leaf|");
+
+    /// @notice The node prefix used to hash to a node.
+    bytes internal constant NODE_PREFIX = bytes("node|");
+
+    /// @notice The root prefix used to hash to a root.
+    bytes internal constant ROOT_PREFIX = bytes("root|");
+
+    /* ============ Custom Errors ============ */
+
+    /// @notice Thrown when the no leaves are passed.
+    error NoLeaves();
+
+    /// @notice Thrown when the input to _roundUpToPowerOf2 is greater than type(uint64).max.
+    error InvalidRoundUpToPowerOf2Input();
+
+    /// @notice Thrown when the input to _bitCount64 is greater than type(uint64).max.
+    error InvalidBitCount64Input();
+
+    /// @notice Thrown when the proof is invalid.
+    error InvalidProof();
+
+    /* ============ Main Functions ============ */
+
+    /**
+     * @notice Verifies a sequential merkle proof.
+     * @param  root_          The root of the merkle tree.
+     * @param  startingIndex_ The index of the first leaf provided.
+     * @param  leaves_        The leaves to prove sequential existence from the starting index.
+     * @param  proofElements_ The merkle proof data.
+     * @dev    proofElements_[0] is the total number of leaves in the merkle tree, the rest are the decommitments.
+     * @dev    Can also revert with an array out-of-bounds access panic.
+     */
+    function verify(
+        uint256 root_,
+        uint256 startingIndex_,
+        bytes[] calldata leaves_,
+        uint256[] calldata proofElements_
+    ) internal pure {
+        require(getRoot(startingIndex_, leaves_, proofElements_) == root_, InvalidProof());
+    }
+
+    /**
+     * @notice Gets the root of a sequential merkle proof.
+     * @param  startingIndex_ The index of the first leaf provided.
+     * @param  leaves_        The leaves to prove sequential existence from the starting index.
+     * @param  proofElements_ The merkle proof data.
+     * @dev    proofElements_[0] is the total number of leaves in the merkle tree, the rest are the decommitments.
+     * @dev    Can also revert with an array out-of-bounds access panic.
+     */
+    function getRoot(
+        uint256 startingIndex_,
+        bytes[] calldata leaves_,
+        uint256[] calldata proofElements_
+    ) internal pure returns (uint256 root_) {
+        require(leaves_.length > 0, NoLeaves());
+
+        return _getRoot(startingIndex_, _getReversedLeafNodesFromLeaves(leaves_), proofElements_);
+    }
+
+    /* ============ Helper Functions ============ */
+
+    /**
+     * @notice Counts number of set bits (1's) in 64-bit unsigned integer.
+     * @dev    See https://en.wikipedia.org/wiki/Hamming_weight implementation `popcount64b`.
+     * @param  n_        The number to count the set bits of.
+     * @return bitCount_ The number of set bits in `n_`.
+     * @dev    Literals are inlined as they are very specific to this algorithm/function, and actually improve
+     *         readability, given their patterns.
+     */
+    function _bitCount64(uint256 n_) internal pure returns (uint256 bitCount_) {
+        require(n_ <= type(uint64).max, InvalidBitCount64Input());
+
+        n_ -= (n_ >> 1) & 0x5555555555555555;
+        n_ = (n_ & 0x3333333333333333) + ((n_ >> 2) & 0x3333333333333333);
+        n_ = (n_ + (n_ >> 4)) & 0x0f0f0f0f0f0f0f0f;
+        n_ += n_ >> 8;
+        n_ += n_ >> 16;
+        n_ += n_ >> 32;
+
+        return n_ & 0x7f;
+    }
+
+    /**
+     * @notice Rounds a 64-bit unsigned integer up to the nearest power of 2.
+     * @param  n_        The number to round up to the nearest power of 2.
+     * @return powerOf2_ The nearest power of 2 to `n_`.
+     * @dev    Literals are inlined as they are very specific to this algorithm/function, and actually improve
+     *         readability, given their patterns.
+     */
+    function _roundUpToPowerOf2(uint256 n_) internal pure returns (uint256 powerOf2_) {
+        require(n_ <= type(uint64).max, InvalidRoundUpToPowerOf2Input());
+
+        if (_bitCount64(n_) == 1) return n_;
+
+        n_ |= n_ >> 1;
+        n_ |= n_ >> 2;
+        n_ |= n_ >> 4;
+        n_ |= n_ >> 8;
+        n_ |= n_ >> 16;
+        n_ |= n_ >> 32;
+
+        return n_ + 1;
+    }
+
+    function _getBalancedLeafCount(uint256 leafCount_) internal pure returns (uint256 balancedLeafCount_) {
+        require(leafCount_ != 0, NoLeaves());
+
+        return leafCount_ == 1 ? 2 : _roundUpToPowerOf2(leafCount_);
+    }
+
+    /**
+     * @notice Gets the root of a sequential merkle proof.
+     * @param  startingIndex_ The index of the first leaf provided.
+     * @param  hashes_        The leaf hashes (in reverse order) to prove sequential existence from the starting index.
+     * @param  proofElements_         The merkle proof data.
+     * @dev    proofElements_[0] is the total number of leaves in the merkle tree, the rest are the decommitments.
+     */
+    function _getRoot(
+        uint256 startingIndex_,
+        uint256[] memory hashes_,
+        uint256[] calldata proofElements_
+    ) internal pure returns (uint256 root_) {
+        uint256 count_ = hashes_.length;
+        uint256[] memory treeIndices_ = new uint256[](count_);
+
+        uint256 readIndex_;
+        uint256 writeIndex_;
+        uint256 proofIndex_ = 1; // proofElements_[0] is the total leaf count, and is already consumed.
+        uint256 upperBound_ = _getBalancedLeafCount(proofElements_[0]) + proofElements_[0] - 1;
+        uint256 lowestTreeIndex_ = _getBalancedLeafCount(proofElements_[0]) + startingIndex_;
+        uint256 highestLeafNodeIndex_ = lowestTreeIndex_ + count_ - 1;
+
+        while (true) {
+            // Instead of doing aa full pass through the empty tree indices array to build a starting sequential set of
+            // indices, we can just check if we are in that "first pass" by checking if `readIndex_ < count_`, and if so
+            // compute the index as needed given the `highestLeafNodeIndex_` and the `readIndex_`.
+            uint256 nodeIndex_ = readIndex_ < count_
+                ? highestLeafNodeIndex_ - readIndex_
+                : treeIndices_[readIndex_ % count_];
+
+            // If we reach the sub-root (i.e. `nodeIndex_ == 1`), we can return the root (i.e. `nodeIndex_ == 0`) by
+            // hashing the tree's leaf count with the last computed hash.
+            if (nodeIndex_ == 1) return _hashRoot(proofElements_[0], hashes_[(writeIndex_ - 1) % count_]);
+
+            // If node index we are handling is the upper bound and is even, then it's sibling to the right does not
+            // exist (since this is an unbalanced tree), so we can just copy the hash up one level.
+            if ((nodeIndex_ == upperBound_) && _isEven(nodeIndex_)) {
+                hashes_[writeIndex_ % count_] = _hashPairlessNode(hashes_[readIndex_++ % count_]);
+                treeIndices_[writeIndex_++ % count_] = nodeIndex_ >> 1;
+
+                // If we are not at the lowest tree index (i.e. there are nodes to the left that we have yet to process
+                // at this level), then continue.
+                if (nodeIndex_ != lowestTreeIndex_) continue;
+
+                // If we are at the lowest tree index (i.e. there are no nodes to the left that we have yet to process
+                // at this level), then we can update the lower bound and upper bound for the next level up.
+                lowestTreeIndex_ >>= 1;
+                upperBound_ >>= 1;
+
+                continue;
+            }
+
+            // Instead of doing aa full pass through the empty tree indices array to build a starting sequential set of
+            // indices, we can just check if we are in that "first pass" by checking if `readIndex_ + 1 < count_`, and
+            // if so compute the next index as needed given the `highestLeafNodeIndex_` and the `readIndex_`.
+            uint256 nextNodeIndex_ = (readIndex_ + 1) < count_
+                ? highestLeafNodeIndex_ - (readIndex_ + 1)
+                : treeIndices_[(readIndex_ + 1) % count_];
+
+            // Since we are processing nodes from right to left, then if the current node index is even, and there
+            // exists nodes to the right (or else the previous if-continue would have been hit), then the right part of
+            // the hash is a decommitment. If the current node index is odd, then the right part of the hash we already
+            // have computed.
+            // NOTE: This is the right part, but reusing the return `root_` variable to save much needed stack space.
+            root_ = _isEven(nodeIndex_) ? proofElements_[proofIndex_++] : hashes_[readIndex_++ % count_];
+
+            // Based on the current node index and the next node index, we can determine if the left part of the hash
+            // is an existing computed hash or a decommitment.
+            uint256 left_ = _isLeftAnExistingHash(nodeIndex_, nextNodeIndex_)
+                ? hashes_[readIndex_++ % count_]
+                : proofElements_[proofIndex_++];
+
+            hashes_[writeIndex_ % count_] = _hashNodePair(left_, root_);
+            treeIndices_[writeIndex_++ % count_] = nodeIndex_ >> 1;
+
+            // If we are not at the lowest tree index (i.e. there are nodes to the left that we have yet to process
+            // at this level), then continue.
+            // NOTE: Technically, if only `nextNodeIndex_ == lowestTreeIndex_`, and we did not use the hash at that
+            // `nextNodeIndex_` as part of this step's hashing, then it was a node not yet handled, but it will be
+            // handled in the next iteration, so the process will continue normally even if we prematurely "leveled up".
+            if (nodeIndex_ != lowestTreeIndex_ && nextNodeIndex_ != lowestTreeIndex_) continue;
+
+            // If we are at the lowest tree index (i.e. there are no nodes to the left that we have yet to process
+            // at this level), then we can update the lower bound and upper bound for the next level up.
+            // NOTE: Again, see the NOTE above.
+            lowestTreeIndex_ >>= 1;
+            upperBound_ >>= 1;
+        }
+    }
+
+    function _isEven(uint256 n_) internal pure returns (bool isEven_) {
+        return (n_ & 1) == 0;
+    }
+
+    /**
+     * @notice Checks if the left part of the hash should be an existing computed hash.
+     * @param  nodeIndex_            The index of the current node in the tree indices array.
+     * @param  nextNodeIndex_        The index of the next (lower) node in the tree indices array.
+     * @return isLeftAnExistingHash_ True if the left part of the hash should be an existing computed hash.
+     */
+    function _isLeftAnExistingHash(
+        uint256 nodeIndex_,
+        uint256 nextNodeIndex_
+    ) internal pure returns (bool isLeftAnExistingHash_) {
+        return _isEven(nodeIndex_) || (nextNodeIndex_ == nodeIndex_ - 1);
+    }
+
+    function _hashLeaf(bytes calldata leaf_) internal pure returns (uint256 node_) {
+        return uint256(keccak256(abi.encodePacked(LEAF_PREFIX, leaf_)));
+    }
+
+    function _hashNodePair(uint256 leftNode_, uint256 rightNode_) internal pure returns (uint256 hash_) {
+        return uint256(keccak256(abi.encodePacked(NODE_PREFIX, leftNode_, rightNode_)));
+    }
+
+    function _hashPairlessNode(uint256 node_) internal pure returns (uint256 hash_) {
+        return uint256(keccak256(abi.encodePacked(NODE_PREFIX, node_)));
+    }
+
+    function _hashRoot(uint256 leafCount_, uint256 root_) internal pure returns (uint256 hash_) {
+        return uint256(keccak256(abi.encodePacked(ROOT_PREFIX, leafCount_, root_)));
+    }
+
+    /// @notice Get leaf nodes from bytes leaves in calldata, in reverse order.
+    function _getReversedLeafNodesFromLeaves(
+        bytes[] calldata leaves_
+    ) internal pure returns (uint256[] memory leafNodes_) {
+        uint256 count_ = leaves_.length;
+        leafNodes_ = new uint256[](count_);
+        uint256 readIndex = count_;
+        uint256 writeIndex;
+
+        while (writeIndex < count_) {
+            leafNodes_[writeIndex++] = _hashLeaf(leaves_[--readIndex]);
+        }
+    }
+}

--- a/src/libraries/SequentialMerkleProofs.sol
+++ b/src/libraries/SequentialMerkleProofs.sol
@@ -22,9 +22,6 @@ library SequentialMerkleProofs {
     /// @notice Thrown when no leaves are provided.
     error NoLeaves();
 
-    /// @notice Thrown when the input to _roundUpToPowerOf2 is greater than type(uint64).max.
-    error InvalidRoundUpToPowerOf2Input();
-
     /// @notice Thrown when the input to _bitCount64 is greater than type(uint64).max.
     error InvalidBitCount64Input();
 
@@ -103,8 +100,6 @@ library SequentialMerkleProofs {
      *         readability, given their patterns.
      */
     function _roundUpToPowerOf2(uint256 n_) internal pure returns (uint256 powerOf2_) {
-        require(n_ <= type(uint64).max, InvalidRoundUpToPowerOf2Input());
-
         if (_bitCount64(n_) == 1) return n_;
 
         unchecked {
@@ -301,7 +296,7 @@ library SequentialMerkleProofs {
     }
 
     /**
-     * @notice Hashes the topmost 32-byte node in the tree, combined with the tree's lead count, into a 32-byte root.
+     * @notice Hashes the topmost 32-byte node in the tree, combined with the tree's leaf count, into a 32-byte root.
      * @param  leafCount_ The number of leaves in the merkle tree.
      * @param  node_      The topmost node in the tree.
      * @return hash_      The root hash of the tree.

--- a/src/libraries/SequentialMerkleProofs.sol
+++ b/src/libraries/SequentialMerkleProofs.sol
@@ -118,9 +118,7 @@ library SequentialMerkleProofs {
      * @return balancedLeafCount_ The balanced leaf count.
      */
     function _getBalancedLeafCount(uint256 leafCount_) internal pure returns (uint256 balancedLeafCount_) {
-        require(leafCount_ != 0, NoLeaves());
-
-        return leafCount_ == 1 ? 2 : _roundUpToPowerOf2(leafCount_);
+        return leafCount_ <= 1 ? (leafCount_ * 2) : _roundUpToPowerOf2(leafCount_);
     }
 
     /**
@@ -135,8 +133,11 @@ library SequentialMerkleProofs {
         bytes32[] memory hashes_,
         bytes32[] calldata proofElements_
     ) internal pure returns (bytes32 root_) {
-        require(hashes_.length > 0, NoLeaves());
         require(proofElements_.length > 0, NoProofElements());
+
+        if (startingIndex_ == 0 && hashes_.length == 0 && uint256(proofElements_[0]) == 0) return bytes32(0);
+
+        require(hashes_.length > 0, NoLeaves());
         require(startingIndex_ + hashes_.length <= uint256(proofElements_[0]), InvalidProof());
 
         uint256 count_ = hashes_.length;

--- a/src/libraries/SequentialMerkleProofs.sol
+++ b/src/libraries/SequentialMerkleProofs.sol
@@ -22,8 +22,8 @@ library SequentialMerkleProofs {
     /// @notice Thrown when no leaves are provided.
     error NoLeaves();
 
-    /// @notice Thrown when the input to _bitCount64 is greater than type(uint64).max.
-    error InvalidBitCount64Input();
+    /// @notice Thrown when the input to _bitCount32 is greater than type(uint32).max.
+    error InvalidBitCount32Input();
 
     /// @notice Thrown when the proof is invalid.
     error InvalidProof();
@@ -70,37 +70,36 @@ library SequentialMerkleProofs {
     /* ============ Helper Functions ============ */
 
     /**
-     * @notice Counts number of set bits (1's) in 64-bit unsigned integer.
+     * @notice Counts number of set bits (1's) in 32-bit unsigned integer.
      * @dev    See https://en.wikipedia.org/wiki/Hamming_weight implementation `popcount64b`.
      * @param  n_        The number to count the set bits of.
      * @return bitCount_ The number of set bits in `n_`.
      * @dev    Literals are inlined as they are very specific to this algorithm/function, and actually improve
      *         readability, given their patterns.
      */
-    function _bitCount64(uint256 n_) internal pure returns (uint256 bitCount_) {
-        require(n_ <= type(uint64).max, InvalidBitCount64Input());
+    function _bitCount32(uint256 n_) internal pure returns (uint256 bitCount_) {
+        require(n_ <= type(uint32).max, InvalidBitCount32Input());
 
         unchecked {
-            n_ -= (n_ >> 1) & 0x5555555555555555;
-            n_ = (n_ & 0x3333333333333333) + ((n_ >> 2) & 0x3333333333333333);
-            n_ = (n_ + (n_ >> 4)) & 0x0f0f0f0f0f0f0f0f;
+            n_ -= (n_ >> 1) & 0x55555555;
+            n_ = (n_ & 0x33333333) + ((n_ >> 2) & 0x33333333);
+            n_ = (n_ + (n_ >> 4)) & 0x0f0f0f0f;
             n_ += n_ >> 8;
             n_ += n_ >> 16;
-            n_ += n_ >> 32;
 
             return n_ & 0x7f;
         }
     }
 
     /**
-     * @notice Rounds a 64-bit unsigned integer up to the nearest power of 2.
+     * @notice Rounds a 632-bit unsigned integer up to the nearest power of 2.
      * @param  n_        The number to round up to the nearest power of 2.
      * @return powerOf2_ The nearest power of 2 to `n_`.
      * @dev    Literals are inlined as they are very specific to this algorithm/function, and actually improve
      *         readability, given their patterns.
      */
     function _roundUpToPowerOf2(uint256 n_) internal pure returns (uint256 powerOf2_) {
-        if (_bitCount64(n_) == 1) return n_;
+        if (_bitCount32(n_) == 1) return n_;
 
         unchecked {
             n_ |= n_ >> 1;
@@ -108,7 +107,6 @@ library SequentialMerkleProofs {
             n_ |= n_ >> 4;
             n_ |= n_ >> 8;
             n_ |= n_ >> 16;
-            n_ |= n_ >> 32;
 
             return n_ + 1;
         }

--- a/src/settlement-chain/NodeRegistry.sol
+++ b/src/settlement-chain/NodeRegistry.sol
@@ -43,7 +43,6 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
      * @param  nodeCount           The current number of nodes.
      * @param  nodes               A mapping of node/token IDs to nodes.
      * @param  admin               The admin address.
-     * @param  nodeManager         The node manager address.
      */
     struct NodeRegistryStorage {
         string baseURI;
@@ -52,7 +51,6 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
         uint32 nodeCount;
         mapping(uint32 tokenId => Node node) nodes;
         address admin;
-        address nodeManager;
     }
 
     // keccak256(abi.encode(uint256(keccak256("xmtp.storage.NodeRegistry")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/settlement-chain/NodeRegistry.sol
+++ b/src/settlement-chain/NodeRegistry.sol
@@ -9,28 +9,20 @@ import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
 
 import { Migratable } from "../abstract/Migratable.sol";
 
-// TODO: `nodeOperatorCommissionPercent` (and thus `MAX_BPS`) likely does not belong in this contract.
+// TODO: Make the rest of the parameters come from the parameter registry.
 
 /**
  * @title  Implementation of the Node Registry
  *
- * @notice This contract is responsible for minting NFTs and assigning them to node operators.
+ * @notice This contract is responsible for minting NFTs and assigning them to node owner.
  *         Each node is minted as an NFT with a unique ID (starting at 100 and increasing by 100 with each new node).
  *         In addition to the standard ERC721 functionality, the contract supports node-specific features,
  *         including node property updates.
  *
  * @dev    All nodes on the network periodically check this contract to determine which nodes they should connect to.
- *         The contract owner is responsible for:
- *           - minting and transferring NFTs to node operators.
- *           - updating the node operator's HTTP address and MTLS certificate.
- *           - updating the node operator's minimum monthly fee.
- *           - updating the node operator's API enabled flag.
  */
 contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     /* ============ Constants/Immutables ============ */
-
-    /// @inheritdoc INodeRegistry
-    uint16 public constant MAX_BPS = 10_000;
 
     /// @inheritdoc INodeRegistry
     uint32 public constant NODE_INCREMENT = 100;
@@ -45,22 +37,20 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     /**
      * @custom:storage-location erc7201:xmtp.storage.NodeRegistry
      * @notice The UUPS storage for the node registry.
-     * @param  baseURI                       The base component of the token URI.
-     * @param  maxCanonicalNodes             The maximum number of canonical nodes.
-     * @param  canonicalNodesCount           The current number of canonical nodes.
-     * @param  nodeCount                     The current number of nodes.
-     * @param  nodeOperatorCommissionPercent The node operator commission percentage.
-     * @param  nodes                         A mapping of node/token IDs to nodes.
-     * @param  admin                         The admin address.
-     * @param  nodeManager                   The node manager address.
+     * @param  baseURI             The base component of the token URI.
+     * @param  maxCanonicalNodes   The maximum number of canonical nodes.
+     * @param  canonicalNodesCount The current number of canonical nodes.
+     * @param  nodeCount           The current number of nodes.
+     * @param  nodes               A mapping of node/token IDs to nodes.
+     * @param  admin               The admin address.
+     * @param  nodeManager         The node manager address.
      */
     struct NodeRegistryStorage {
         string baseURI;
         uint8 maxCanonicalNodes;
         uint8 canonicalNodesCount;
         uint32 nodeCount;
-        uint16 nodeOperatorCommissionPercent;
-        mapping(uint256 tokenId => Node node) nodes;
+        mapping(uint32 tokenId => Node node) nodes;
         address admin;
         address nodeManager;
     }
@@ -83,11 +73,6 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
         _;
     }
 
-    modifier onlyNodeManager() {
-        _revertIfNotNodeManager();
-        _;
-    }
-
     /* ============ Constructor ============ */
 
     /**
@@ -105,41 +90,44 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
 
     /// @inheritdoc INodeRegistry
     function initialize() public initializer {
-        __ERC721_init("XMTP Node Operator", "XMTP");
+        __ERC721_init("XMTP Nodes", "nXMTP");
 
         // TODO: This should probably come from the parameter registry.
         _getNodeRegistryStorage().maxCanonicalNodes = 20;
     }
 
-    /* ============ Admin-Only Functions ============ */
+    /* ============ Admin Functions ============ */
 
     /// @inheritdoc INodeRegistry
     function addNode(
-        address to_,
-        bytes calldata signingKeyPub_,
-        string calldata httpAddress_,
-        uint256 minMonthlyFee_
-    ) external onlyAdmin returns (uint256 nodeId_) {
-        require(to_ != address(0), InvalidAddress());
-        require(signingKeyPub_.length > 0, InvalidSigningKey());
+        address owner_,
+        bytes calldata signingPublicKey_,
+        string calldata httpAddress_
+    ) external onlyAdmin returns (uint32 nodeId_, address signer_) {
+        require(owner_ != address(0), InvalidOwner());
+        require(signingPublicKey_.length > 0, InvalidSigningPublicKey());
         require(bytes(httpAddress_).length > 0, InvalidHttpAddress());
 
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
 
+        require((uint256($.nodeCount) + 1) * NODE_INCREMENT <= type(uint32).max, MaxNodesReached());
+
         unchecked {
-            nodeId_ = uint256(++$.nodeCount) * NODE_INCREMENT; // The first node starts with `nodeId_ = NODE_INCREMENT`.
+            nodeId_ = ++$.nodeCount * NODE_INCREMENT; // The first node starts with `nodeId_ = NODE_INCREMENT`.
         }
 
+        signer_ = _toAddress(keccak256(signingPublicKey_));
+
         // Nodes start off as non-canonical.
-        $.nodes[nodeId_] = Node(signingKeyPub_, httpAddress_, false, minMonthlyFee_);
+        $.nodes[nodeId_] = Node(signer_, false, signingPublicKey_, httpAddress_);
 
-        _mint(to_, nodeId_);
+        _mint(owner_, nodeId_);
 
-        emit NodeAdded(nodeId_, to_, signingKeyPub_, httpAddress_, minMonthlyFee_);
+        emit NodeAdded(nodeId_, owner_, signer_, signingPublicKey_, httpAddress_);
     }
 
     /// @inheritdoc INodeRegistry
-    function addToNetwork(uint256 nodeId_) external onlyAdmin {
+    function addToNetwork(uint32 nodeId_) external onlyAdmin {
         _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
 
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
@@ -153,7 +141,7 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     }
 
     /// @inheritdoc INodeRegistry
-    function removeFromNetwork(uint256 nodeId_) external onlyAdmin {
+    function removeFromNetwork(uint32 nodeId_) external onlyAdmin {
         _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
 
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
@@ -174,32 +162,19 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     }
 
     /// @inheritdoc INodeRegistry
-    function setNodeOperatorCommissionPercent(uint16 newCommissionPercent_) external onlyAdmin {
-        require(newCommissionPercent_ <= MAX_BPS, InvalidCommissionPercent());
-        _getNodeRegistryStorage().nodeOperatorCommissionPercent = newCommissionPercent_;
-        emit NodeOperatorCommissionPercentUpdated(newCommissionPercent_);
-    }
-
-    /// @inheritdoc INodeRegistry
     function setBaseURI(string calldata newBaseURI_) external onlyAdmin {
         require(bytes(newBaseURI_).length > 0, InvalidURI());
         require(bytes(newBaseURI_)[bytes(newBaseURI_).length - 1] == _FORWARD_SLASH, InvalidURI());
         emit BaseURIUpdated(_getNodeRegistryStorage().baseURI = newBaseURI_);
     }
 
-    /* ============ Node Manager Functions ============ */
+    /* ============ Node Owner Functions ============ */
 
     /// @inheritdoc INodeRegistry
-    function setHttpAddress(uint256 nodeId_, string calldata httpAddress_) external onlyNodeManager {
-        _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
+    function setHttpAddress(uint32 nodeId_, string calldata httpAddress_) external {
+        _revertIfNotNodeOwner(nodeId_);
         require(bytes(httpAddress_).length > 0, InvalidHttpAddress());
         emit HttpAddressUpdated(nodeId_, _getNodeRegistryStorage().nodes[nodeId_].httpAddress = httpAddress_);
-    }
-
-    /// @inheritdoc INodeRegistry
-    function setMinMonthlyFee(uint256 nodeId_, uint256 minMonthlyFee_) external onlyNodeManager {
-        _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
-        emit MinMonthlyFeeUpdated(nodeId_, _getNodeRegistryStorage().nodes[nodeId_].minMonthlyFee = minMonthlyFee_);
     }
 
     /* ============ Interactive Functions ============ */
@@ -215,17 +190,6 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
         emit AdminUpdated($.admin = newAdmin_);
     }
 
-    /// @inheritdoc INodeRegistry
-    function updateNodeManager() external {
-        NodeRegistryStorage storage $ = _getNodeRegistryStorage();
-
-        address newNodeManager_ = _toAddress(_getRegistryParameter(nodeManagerParameterKey()));
-
-        require(newNodeManager_ != $.nodeManager, NoChange());
-
-        emit NodeManagerUpdated($.nodeManager = newNodeManager_);
-    }
-
     /// @inheritdoc IMigratable
     function migrate() external {
         _migrate(_toAddress(_getRegistryParameter(migratorParameterKey())));
@@ -239,18 +203,8 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     }
 
     /// @inheritdoc INodeRegistry
-    function nodeManager() external view returns (address nodeManager_) {
-        return _getNodeRegistryStorage().nodeManager;
-    }
-
-    /// @inheritdoc INodeRegistry
     function adminParameterKey() public pure returns (bytes memory key_) {
         return bytes("xmtp.nodeRegistry.admin");
-    }
-
-    /// @inheritdoc INodeRegistry
-    function nodeManagerParameterKey() public pure returns (bytes memory key_) {
-        return bytes("xmtp.nodeRegistry.nodeManager");
     }
 
     /// @inheritdoc INodeRegistry
@@ -269,37 +223,38 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     }
 
     /// @inheritdoc INodeRegistry
-    function nodeOperatorCommissionPercent() external view returns (uint16 nodeOperatorCommissionPercent_) {
-        return _getNodeRegistryStorage().nodeOperatorCommissionPercent;
-    }
-
-    /// @inheritdoc INodeRegistry
     function getAllNodes() external view returns (NodeWithId[] memory allNodes_) {
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
 
         allNodes_ = new NodeWithId[]($.nodeCount);
 
         for (uint32 index_; index_ < $.nodeCount; ++index_) {
-            uint256 nodeId_ = uint256(NODE_INCREMENT) * (index_ + 1);
+            uint32 nodeId_ = NODE_INCREMENT * (index_ + 1);
             allNodes_[index_] = NodeWithId({ nodeId: nodeId_, node: $.nodes[nodeId_] });
         }
     }
 
     /// @inheritdoc INodeRegistry
-    function getAllNodesCount() external view returns (uint256 nodeCount_) {
+    function getAllNodesCount() external view returns (uint32 nodeCount_) {
         return _getNodeRegistryStorage().nodeCount;
     }
 
     /// @inheritdoc INodeRegistry
-    function getNode(uint256 nodeId_) external view returns (Node memory node_) {
+    function getNode(uint32 nodeId_) external view returns (Node memory node_) {
         _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
         return _getNodeRegistryStorage().nodes[nodeId_];
     }
 
     /// @inheritdoc INodeRegistry
-    function getIsCanonicalNode(uint256 nodeId_) external view returns (bool isCanonicalNode_) {
+    function getIsCanonicalNode(uint32 nodeId_) external view returns (bool isCanonicalNode_) {
         _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
         return _getNodeRegistryStorage().nodes[nodeId_].isCanonical;
+    }
+
+    /// @inheritdoc INodeRegistry
+    function getSigner(uint32 nodeId_) external view returns (address signer_) {
+        _requireOwned(nodeId_); // Reverts if the nodeId/tokenId does not exist.
+        return _getNodeRegistryStorage().nodes[nodeId_].signer;
     }
 
     /* ============ Internal View/Pure Functions ============ */
@@ -323,23 +278,11 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
         }
     }
 
-    /**
-     * @dev Overrides the `ERC721Upgradeable._isAuthorized` function to allow the node manager to transfer a token on
-     *      behalf of any nodeId/tokenId. If the spender is not the node manager, default ERC721 permissioning is used.
-     */
-    function _isAuthorized(
-        address owner_,
-        address spender_,
-        uint256 tokenId_
-    ) internal view override returns (bool isAuthorized_) {
-        return spender_ == _getNodeRegistryStorage().nodeManager || super._isAuthorized(owner_, spender_, tokenId_);
-    }
-
     function _revertIfNotAdmin() internal view {
         require(msg.sender == _getNodeRegistryStorage().admin, NotAdmin());
     }
 
-    function _revertIfNotNodeManager() internal view {
-        require(msg.sender == _getNodeRegistryStorage().nodeManager, NotNodeManager());
+    function _revertIfNotNodeOwner(uint32 nodeId_) internal view {
+        require(_requireOwned(nodeId_) == msg.sender, NotNodeOwner());
     }
 }

--- a/src/settlement-chain/interfaces/INodeRegistry.sol
+++ b/src/settlement-chain/interfaces/INodeRegistry.sol
@@ -19,16 +19,16 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
 
     /**
      * @notice Struct representing a node in the registry.
-     * @param  signingKeyPub The public key used for node signing/verification.
-     * @param  httpAddress   The HTTP endpoint address for the node.
-     * @param  isCanonical   A flag indicating whether the node is part of the canonical network.
-     * @param  minMonthlyFee The minimum monthly fee collected by the node operator.
+     * @param  signer           The address derived by the signing public key, for convenience.
+     * @param  isCanonical      A flag indicating whether the node is part of the canonical network.
+     * @param  signingPublicKey The public key used for node signing/verification.
+     * @param  httpAddress      The HTTP endpoint address for the node.
      */
     struct Node {
-        bytes signingKeyPub;
-        string httpAddress;
+        address signer;
         bool isCanonical;
-        uint256 minMonthlyFee;
+        bytes signingPublicKey;
+        string httpAddress;
     }
 
     /**
@@ -37,7 +37,7 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
      * @param  node   The node struct.
      */
     struct NodeWithId {
-        uint256 nodeId;
+        uint32 nodeId;
         Node node;
     }
 
@@ -50,12 +50,6 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
     event AdminUpdated(address indexed admin);
 
     /**
-     * @notice Emitted when the node manager is updated.
-     * @param  nodeManager The new node manager.
-     */
-    event NodeManagerUpdated(address indexed nodeManager);
-
-    /**
      * @notice Emitted when the base URI is updated.
      * @param  baseURI The new base URI.
      */
@@ -66,7 +60,7 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
      * @param  nodeId      The identifier of the node.
      * @param  httpAddress The new HTTP address.
      */
-    event HttpAddressUpdated(uint256 indexed nodeId, string httpAddress);
+    event HttpAddressUpdated(uint32 indexed nodeId, string httpAddress);
 
     /**
      * @notice Emitted when the maximum number of canonical nodes is updated.
@@ -75,45 +69,32 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
     event MaxCanonicalNodesUpdated(uint8 maxCanonicalNodes);
 
     /**
-     * @notice Emitted when the minimum monthly fee for a node is updated.
-     * @param  nodeId        The identifier of the node.
-     * @param  minMonthlyFee The updated minimum fee.
-     */
-    event MinMonthlyFeeUpdated(uint256 indexed nodeId, uint256 minMonthlyFee);
-
-    /**
      * @notice Emitted when a new node is added and its NFT minted.
-     * @param  nodeId        The unique identifier for the node (starts at 100, increments by 100).
-     * @param  owner         The address that receives the new node NFT.
-     * @param  signingKeyPub The node’s signing key public value.
-     * @param  httpAddress   The node’s HTTP endpoint.
-     * @param  minMonthlyFee The minimum monthly fee for the node.
+     * @param  nodeId           The unique identifier for the node (starts at 100, increments by 100).
+     * @param  owner            The address that receives the new node NFT.
+     * @param  signer           The address derived by the signing public key, for convenience.
+     * @param  signingPublicKey The public key used for node signing/verification.
+     * @param  httpAddress      The node’s HTTP endpoint.
      */
     event NodeAdded(
-        uint256 indexed nodeId,
+        uint32 indexed nodeId,
         address indexed owner,
-        bytes signingKeyPub,
-        string httpAddress,
-        uint256 minMonthlyFee
+        address indexed signer,
+        bytes signingPublicKey,
+        string httpAddress
     );
 
     /**
      * @notice Emitted when a node is added to the canonical network.
      * @param  nodeId The identifier of the node.
      */
-    event NodeAddedToCanonicalNetwork(uint256 indexed nodeId);
+    event NodeAddedToCanonicalNetwork(uint32 indexed nodeId);
 
     /**
      * @notice Emitted when a node is removed from the canonical network.
      * @param  nodeId The identifier of the node.
      */
-    event NodeRemovedFromCanonicalNetwork(uint256 indexed nodeId);
-
-    /**
-     * @notice Emitted when the node operator commission percent is updated.
-     * @param  commissionPercent The new commission percentage.
-     */
-    event NodeOperatorCommissionPercentUpdated(uint16 commissionPercent);
+    event NodeRemovedFromCanonicalNetwork(uint32 indexed nodeId);
 
     /* ============ Custom Errors ============ */
 
@@ -126,17 +107,14 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
     /// @notice Thrown when failing to remove a node from the canonical network.
     error FailedToRemoveNodeFromCanonicalNetwork();
 
-    /// @notice Thrown when an invalid address is provided.
-    error InvalidAddress();
-
-    /// @notice Thrown when an invalid commission percentage is provided.
-    error InvalidCommissionPercent();
+    /// @notice Thrown when an invalid owner is provided.
+    error InvalidOwner();
 
     /// @notice Thrown when an invalid HTTP address is provided.
     error InvalidHttpAddress();
 
-    /// @notice Thrown when an invalid signing key is provided.
-    error InvalidSigningKey();
+    /// @notice Thrown when an invalid signing public key is provided.
+    error InvalidSigningPublicKey();
 
     /// @notice Thrown when an invalid URI is provided.
     error InvalidURI();
@@ -159,8 +137,11 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
     /// @notice Thrown when the caller is not the admin.
     error NotAdmin();
 
-    /// @notice Thrown when the caller is not the node manager.
-    error NotNodeManager();
+    /// @notice Thrown when the maximum number of nodes is reached.
+    error MaxNodesReached();
+
+    /// @notice Thrown when the caller is not the node owner.
+    error NotNodeOwner();
 
     /* ============ Initialization ============ */
 
@@ -173,37 +154,30 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
 
     /**
      * @notice Adds a new node to the registry and mints its corresponding ERC721 token.
+     * @param  owner_            The address that will own the new node node/NFT.
+     * @param  signingPublicKey_ The public key used for node signing/verification.
+     * @param  httpAddress_      The node’s HTTP address.
+     * @return nodeId_           The unique identifier of the newly added node.
+     * @return signer_           The address derived by the signing public key, for convenience.
      * @dev    Node IDs start at 100 and increase by 100 for each new node.
-     * @param  to_            The address that will own the new node NFT.
-     * @param  signingKeyPub_ The public signing key for the node.
-     * @param  httpAddress_   The node’s HTTP address.
-     * @param  minMonthlyFee_ The minimum monthly fee that the node operator collects.
-     * @return nodeId_        The unique identifier of the newly added node.
      */
     function addNode(
-        address to_,
-        bytes calldata signingKeyPub_,
-        string calldata httpAddress_,
-        uint256 minMonthlyFee_
-    ) external returns (uint256 nodeId_);
+        address owner_,
+        bytes calldata signingPublicKey_,
+        string calldata httpAddress_
+    ) external returns (uint32 nodeId_, address signer_);
 
     /**
      * @notice Adds a node to the canonical network.
      * @param  nodeId_ The unique identifier of the node.
      */
-    function addToNetwork(uint256 nodeId_) external;
+    function addToNetwork(uint32 nodeId_) external;
 
     /**
      * @notice Removes a node from the canonical network.
      * @param  nodeId_ The unique identifier of the node.
      */
-    function removeFromNetwork(uint256 nodeId_) external;
-
-    /**
-     * @notice Sets the commission percentage that the node operator receives.
-     * @param  newCommissionPercent_ The new commission percentage.
-     */
-    function setNodeOperatorCommissionPercent(uint16 newCommissionPercent_) external;
+    function removeFromNetwork(uint32 nodeId_) external;
 
     /**
      * @notice Sets the maximum number of canonical nodes.
@@ -224,14 +198,7 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
      * @param  nodeId_      The unique identifier of the node.
      * @param  httpAddress_ The new HTTP address.
      */
-    function setHttpAddress(uint256 nodeId_, string calldata httpAddress_) external;
-
-    /**
-     * @notice Set the minimum monthly fee for a node.
-     * @param  nodeId_        The unique identifier of the node.
-     * @param  minMonthlyFee_ The new minimum monthly fee.
-     */
-    function setMinMonthlyFee(uint256 nodeId_, uint256 minMonthlyFee_) external;
+    function setHttpAddress(uint32 nodeId_, string calldata httpAddress_) external;
 
     /* ============ Interactive Functions ============ */
 
@@ -240,16 +207,7 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
      */
     function updateAdmin() external;
 
-    /**
-     * @notice Updates the node manager by referring to the last node manager parameter from the parameter registry.
-     */
-    function updateNodeManager() external;
-
     /* ============ View/Pure Functions ============ */
-
-    /// @notice The maximum commission percentage that the node operator can receive (100% in basis points).
-    // slither-disable-next-line naming-convention
-    function MAX_BPS() external pure returns (uint16 maxBps_);
 
     /// @notice The increment for node IDs, which allows for 100 shard node IDs per node in the future (modulus 100).
     // slither-disable-next-line naming-convention
@@ -258,14 +216,8 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
     /// @notice The address of the admin.
     function admin() external view returns (address admin_);
 
-    /// @notice The address of the node manager.
-    function nodeManager() external view returns (address nodeManager_);
-
     /// @notice The parameter registry key used to fetch the admin.
     function adminParameterKey() external pure returns (bytes memory key_);
-
-    /// @notice The parameter registry key used to fetch the node manager.
-    function nodeManagerParameterKey() external pure returns (bytes memory key_);
 
     /// @notice The parameter registry key used to fetch the migrator.
     function migratorParameterKey() external pure returns (bytes memory key_);
@@ -279,9 +231,6 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
     /// @notice The number of nodes that are part of the canonical network.
     function canonicalNodesCount() external view returns (uint8 canonicalNodesCount_);
 
-    /// @notice The commission percentage that the node operator receives.
-    function nodeOperatorCommissionPercent() external view returns (uint16 commissionPercent_);
-
     /**
      * @notice Gets all nodes regardless of their health status.
      * @return allNodes_ An array of all nodes in the registry.
@@ -292,19 +241,26 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
      * @notice Gets the total number of nodes in the registry.
      * @return nodeCount_ The total number of nodes.
      */
-    function getAllNodesCount() external view returns (uint256 nodeCount_);
+    function getAllNodesCount() external view returns (uint32 nodeCount_);
 
     /**
      * @notice Retrieves the details of a given node.
      * @param  nodeId_ The unique identifier of the node.
      * @return node_   The Node struct containing the node's details.
      */
-    function getNode(uint256 nodeId_) external view returns (Node memory node_);
+    function getNode(uint32 nodeId_) external view returns (Node memory node_);
 
     /**
      * @notice Retrieves whether a node is part of the canonical network.
      * @param  nodeId_          The unique identifier of the node.
      * @return isCanonicalNode_ A boolean indicating whether the node is part of the canonical network.
      */
-    function getIsCanonicalNode(uint256 nodeId_) external view returns (bool isCanonicalNode_);
+    function getIsCanonicalNode(uint32 nodeId_) external view returns (bool isCanonicalNode_);
+
+    /**
+     * @notice Retrieves the signer of a node.
+     * @param  nodeId_ The unique identifier of the node.
+     * @return signer_ The address of the signer.
+     */
+    function getSigner(uint32 nodeId_) external view returns (address signer_);
 }

--- a/src/settlement-chain/interfaces/INodeRegistry.sol
+++ b/src/settlement-chain/interfaces/INodeRegistry.sol
@@ -191,7 +191,7 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable 
      */
     function setBaseURI(string calldata newBaseURI_) external;
 
-    /* ============ Node Manager Functions ============ */
+    /* ============ Node Owner Functions ============ */
 
     /**
      * @notice Set the HTTP address of an existing node.

--- a/test/integration/DeploymentTests.t.sol
+++ b/test/integration/DeploymentTests.t.sol
@@ -67,7 +67,6 @@ contract DeploymentTests is Test {
     bytes internal constant _RATE_REGISTRY_TARGET_RATE_PER_MINUTE_KEY = "xmtp.rateRegistry.targetRatePerMinute";
 
     bytes internal constant _NODE_REGISTRY_ADMIN_KEY = "xmtp.nodeRegistry.admin";
-    bytes internal constant _NODE_REGISTRY_NODE_MANAGER_KEY = "xmtp.nodeRegistry.nodeManager";
 
     uint256 internal constant _GROUP_MESSAGE_BROADCASTER_STARTING_MIN_PAYLOAD_SIZE = 78;
     uint256 internal constant _GROUP_MESSAGE_BROADCASTER_STARTING_MAX_PAYLOAD_SIZE = 4_194_304;
@@ -94,7 +93,6 @@ contract DeploymentTests is Test {
     uint8 internal constant _RETRYABLE_TICKET_KIND = 9;
 
     address internal _admin = makeAddr("admin");
-    address internal _nodeManager = makeAddr("nodeManager");
     address internal _alice = makeAddr("alice");
     address internal _settler = makeAddr("settler");
     address internal _feeDistributor = makeAddr("feeDistributor");
@@ -237,8 +235,8 @@ contract DeploymentTests is Test {
         // Set the parameters as need for the Node Registry.
         _setNodeRegistryStartingParameters();
 
-        // Update the Node Registry admin and node manager.
-        _updateNodeRegistryAdminAndNodeManager();
+        // Update the Node Registry admin.
+        _updateNodeRegistryAdmin();
     }
 
     /* ============ Factory Deployer Helpers ============ */
@@ -605,16 +603,13 @@ contract DeploymentTests is Test {
         assertEq(registry_.implementation(), implementation_);
     }
 
-    function _updateNodeRegistryAdminAndNodeManager() internal {
+    function _updateNodeRegistryAdmin() internal {
         vm.selectFork(_baseForkId);
 
-        vm.startPrank(_alice);
+        vm.prank(_alice);
         _nodeRegistryProxy.updateAdmin();
-        _nodeRegistryProxy.updateNodeManager();
-        vm.stopPrank();
 
         assertEq(_nodeRegistryProxy.admin(), _admin);
-        assertEq(_nodeRegistryProxy.nodeManager(), _nodeManager);
     }
 
     /* ============ Generic Deployer Helpers ============ */
@@ -716,19 +711,16 @@ contract DeploymentTests is Test {
     function _setNodeRegistryStartingParameters() internal {
         vm.selectFork(_baseForkId);
 
-        bytes[] memory keys_ = new bytes[](2);
+        bytes[] memory keys_ = new bytes[](1);
         keys_[0] = _NODE_REGISTRY_ADMIN_KEY;
-        keys_[1] = _NODE_REGISTRY_NODE_MANAGER_KEY;
 
-        bytes32[] memory values_ = new bytes32[](2);
+        bytes32[] memory values_ = new bytes32[](1);
         values_[0] = bytes32(uint256(uint160(_admin)));
-        values_[1] = bytes32(uint256(uint160(_nodeManager)));
 
         vm.prank(_admin);
         _settlementChainParameterRegistryProxy.set(keys_, values_);
 
         assertEq(_settlementChainParameterRegistryProxy.get(keys_[0]), values_[0]);
-        assertEq(_settlementChainParameterRegistryProxy.get(keys_[1]), values_[1]);
     }
 
     function _bridgeBroadcasterStartingParameters() internal {

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -381,7 +381,7 @@ contract SequentialMerkleProofsTests is Test {
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
 
-        vm.expectRevert(stdError.indexOOBError);
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd3");
@@ -634,6 +634,16 @@ contract SequentialMerkleProofsTests is Test {
     function test_getRoot_noLeaves() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
         _sequentialMerkleProofs.getRoot(0, new bytes[](0), new uint256[](0));
+    }
+
+    function test_getRoot_noProofElements() external {
+        vm.expectRevert(SequentialMerkleProofs.NoProofElements.selector);
+        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new uint256[](0));
+    }
+
+    function test_getRoot_invalidProof() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new uint256[](1));
     }
 
     function test_getRoot_invalidRoundUpToPowerOf2Input() external {

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -1,0 +1,902 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Test, stdError } from "../../lib/forge-std/src/Test.sol";
+
+import { SequentialMerkleProofs } from "../../src/libraries/SequentialMerkleProofs.sol";
+
+import { SequentialMerkleProofsHarness } from "../utils/Harnesses.sol";
+
+contract SequentialMerkleProofsTests is Test {
+    SequentialMerkleProofsHarness internal _sequentialMerkleProofs;
+
+    function setUp() external {
+        _sequentialMerkleProofs = new SequentialMerkleProofsHarness();
+    }
+
+    function test_hashLeaf() external {
+        assertEq(
+            bytes32(_sequentialMerkleProofs.__hashLeaf("Hello")),
+            0x0b8faa8dd08a172ebf9582ef1c73d06a82e28d18c61a8b47b13d01f1740e9a11
+        );
+
+        assertEq(
+            bytes32(_sequentialMerkleProofs.__hashLeaf("World")),
+            0x817d5a47d8f38274199af57907aa20a633a5f767439cfc22e11a5dd5a4493f2a
+        );
+
+        assertEq(
+            bytes32(_sequentialMerkleProofs.__hashLeaf("Lorem ipsum dolor sit amet")),
+            0xa5dc43044db877acef8181b04b78a81c39a01d8ba78e29a5fe06a99732e626d3
+        );
+
+        assertEq(
+            bytes32(_sequentialMerkleProofs.__hashLeaf("Lorem ipsum dolor sit amet consectetur adipiscing elit")),
+            0xa5fe16054246ec55b4c4f376e432cce9f5d7e9c6859bf2801c1d05e0a187341c
+        );
+    }
+
+    function test_hashNodePair() external {
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashNodePair(
+                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
+                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+                )
+            ),
+            0x30c08f17fca6d5b183fd798df2c94be55f9191aa17b64e14af24dea51d56a200
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashNodePair(
+                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
+                    0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
+                )
+            ),
+            0xaf45a9d3cd256488928e96458a0fe6bde6182c416dad6228c15900570ad4ce86
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashNodePair(
+                    0x0000000000000000000000000000000000000000000000000000000000000000,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                )
+            ),
+            0xcf86af75a8a3ad149001943d69c6f6baf87e648e765e365f9aea84c06a306fea
+        );
+    }
+
+    function test_hashPairlessNode() external {
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashPairlessNode(
+                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+                )
+            ),
+            0x4bde7d5c3f4483ac1642c0f72078ce38639cca66529ce401be6200d03194f0a5
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashPairlessNode(
+                    0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
+                )
+            ),
+            0x26960017dbb60afc80dfcc5a6ccbfa17711de9e934a46ae4532a79ac33344a02
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashPairlessNode(
+                    0x0000000000000000000000000000000000000000000000000000000000000000
+                )
+            ),
+            0xeb14eebf6aaf45d22d20a202b833f1d484603044dea188a8eb1585c22d01a41f
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashPairlessNode(
+                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                )
+            ),
+            0x2f8f0f26e7f767c7dea71e75bf4f70510db5b05f50e842eeb6dc09d678b87640
+        );
+    }
+
+    function test_hashRoot() external {
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashRoot(
+                    1,
+                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+                )
+            ),
+            0x42bdfcbf85f7e8aafa85a4c4ce995c0f8413225503d8b5aeaadaa7a044083acb
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashRoot(
+                    78,
+                    0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
+                )
+            ),
+            0xda04fbfbac2808039eaf34829fbb30df8855c1589785cb5764e23b1b32fd2537
+        );
+
+        assertEq(
+            bytes32(
+                _sequentialMerkleProofs.__hashRoot(
+                    46984,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                )
+            ),
+            0x6bd1491b7fd13801bace4086092489a8e34ac0c15920d1ad7921e0f402eae63e
+        );
+    }
+
+    function test_verify_noLeafs() external {
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new uint256[](0));
+    }
+
+    function test_verify_invalidRoundUpToPowerOf2Input() external {
+        bytes[] memory leaves_ = new bytes[](1);
+        leaves_[0] = bytes(hex"00");
+
+        uint256[] memory proofElements_ = new uint256[](1);
+        proofElements_[0] = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+        _sequentialMerkleProofs.verify(0, 0, leaves_, proofElements_);
+    }
+
+    function test_verify_balanced_sample1() external {
+        uint256 startingIndex_ = 0;
+        uint256 leafCount_ = 2;
+
+        bytes[] memory leaves_ = new bytes[](1);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        uint256[] memory proofElements_ = new uint256[](2);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
+
+        uint256 root_ = uint256(0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_balanced_sample1_invalidProof() external {
+        uint256 startingIndex_ = 0;
+        uint256 leafCount_ = 2;
+
+        bytes[] memory leaves_ = new bytes[](1);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        uint256[] memory proofElements_ = new uint256[](2);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
+
+        uint256 root_ = uint256(0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd1");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59a;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_balanced_sample2() external {
+        uint256 startingIndex_ = 1;
+        uint256 leafCount_ = 8;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
+        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
+        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
+        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+
+        uint256[] memory proofElements_ = new uint256[](4);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
+        proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
+        proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
+
+        uint256 root_ = uint256(0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_balanced_sample2_invalidProof() external {
+        uint256 startingIndex_ = 1;
+        uint256 leafCount_ = 8;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
+        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
+        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
+        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+
+        uint256[] memory proofElements_ = new uint256[](4);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
+        proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
+        proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
+
+        uint256 root_ = uint256(0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee32");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d86;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_balanced_sample3() external {
+        uint256 startingIndex_ = 9;
+        uint256 leafCount_ = 16;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        uint256[] memory proofElements_ = new uint256[](5);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
+        proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
+        proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        uint256 root_ = uint256(0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_balanced_sample3_invalidProof() external {
+        uint256 startingIndex_ = 9;
+        uint256 leafCount_ = 16;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        uint256[] memory proofElements_ = new uint256[](5);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
+        proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
+        proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        uint256 root_ = uint256(0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b3");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d5;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample1() external {
+        uint256 startingIndex_ = 0;
+        uint256 leafCount_ = 1;
+
+        bytes[] memory leaves_ = new bytes[](1);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        uint256[] memory proofElements_ = new uint256[](1);
+
+        proofElements_[0] = leafCount_;
+
+        uint256 root_ = uint256(0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample1_invalidProof() external {
+        uint256 startingIndex_ = 0;
+        uint256 leafCount_ = 1;
+
+        bytes[] memory leaves_ = new bytes[](1);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        uint256[] memory proofElements_ = new uint256[](1);
+
+        proofElements_[0] = leafCount_;
+
+        uint256 root_ = uint256(0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd3");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample2() external {
+        uint256 startingIndex_ = 4;
+        uint256 leafCount_ = 7;
+
+        bytes[] memory leaves_ = new bytes[](2);
+
+        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+        leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
+
+        uint256[] memory proofElements_ = new uint256[](3);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
+        proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
+
+        uint256 root_ = uint256(0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample2_invalidProof() external {
+        uint256 startingIndex_ = 4;
+        uint256 leafCount_ = 7;
+
+        bytes[] memory leaves_ = new bytes[](2);
+
+        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+        leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
+
+        uint256[] memory proofElements_ = new uint256[](3);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
+        proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
+
+        uint256 root_ = uint256(0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c68");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de837;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample3() external {
+        uint256 startingIndex_ = 9;
+        uint256 leafCount_ = 13;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        uint256[] memory proofElements_ = new uint256[](3);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        uint256 root_ = uint256(0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample3_invalidProof() external {
+        uint256 startingIndex_ = 9;
+        uint256 leafCount_ = 13;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        uint256[] memory proofElements_ = new uint256[](3);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        uint256 root_ = uint256(0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b3");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93b;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample4() external {
+        uint256 startingIndex_ = 200;
+        uint256 leafCount_ = 324;
+
+        bytes[] memory leaves_ = new bytes[](22);
+
+        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
+        leaves_[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
+        leaves_[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
+        leaves_[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
+        leaves_[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
+        leaves_[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
+        leaves_[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
+        leaves_[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
+        leaves_[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
+        leaves_[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
+        leaves_[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
+        leaves_[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
+        leaves_[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
+        leaves_[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
+        leaves_[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
+        leaves_[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
+        leaves_[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
+        leaves_[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
+        leaves_[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
+        leaves_[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
+        leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
+        leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
+
+        uint256[] memory proofElements_ = new uint256[](7);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
+        proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
+        proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
+        proofElements_[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
+        proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
+        proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
+
+        uint256 root_ = uint256(0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c);
+
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_verify_unbalanced_sample4_invalidProof() external {
+        uint256 startingIndex_ = 200;
+        uint256 leafCount_ = 324;
+
+        bytes[] memory leaves_ = new bytes[](22);
+
+        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
+        leaves_[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
+        leaves_[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
+        leaves_[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
+        leaves_[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
+        leaves_[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
+        leaves_[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
+        leaves_[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
+        leaves_[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
+        leaves_[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
+        leaves_[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
+        leaves_[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
+        leaves_[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
+        leaves_[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
+        leaves_[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
+        leaves_[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
+        leaves_[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
+        leaves_[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
+        leaves_[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
+        leaves_[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
+        leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
+        leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
+
+        uint256[] memory proofElements_ = new uint256[](7);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
+        proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
+        proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
+        proofElements_[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
+        proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
+        proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
+
+        uint256 root_ = uint256(0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+
+        vm.expectRevert(stdError.indexOOBError);
+        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3e");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
+        proofElements_[0] = leafCount_ + 1;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1213;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function test_getRoot_noLeaves() external {
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        _sequentialMerkleProofs.getRoot(0, new bytes[](0), new uint256[](0));
+    }
+
+    function test_getRoot_invalidRoundUpToPowerOf2Input() external {
+        bytes[] memory leaves_ = new bytes[](1);
+        leaves_[0] = bytes(hex"00");
+
+        uint256[] memory proofElements_ = new uint256[](1);
+        proofElements_[0] = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+        _sequentialMerkleProofs.getRoot(0, leaves_, proofElements_);
+    }
+
+    function test_getRoot_balanced_sample1() external {
+        uint256 startingIndex_ = 0;
+        uint256 leafCount_ = 2;
+
+        bytes[] memory leaves_ = new bytes[](1);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        uint256[] memory proofElements_ = new uint256[](2);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
+
+        uint256 expectedRoot_ = uint256(0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_getRoot_balanced_sample2() external {
+        uint256 startingIndex_ = 1;
+        uint256 leafCount_ = 8;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
+        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
+        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
+        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+
+        uint256[] memory proofElements_ = new uint256[](4);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
+        proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
+        proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
+
+        uint256 expectedRoot_ = uint256(0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_getRoot_balanced_sample3() external {
+        uint256 startingIndex_ = 9;
+        uint256 leafCount_ = 16;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        uint256[] memory proofElements_ = new uint256[](5);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
+        proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
+        proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        uint256 expectedRoot_ = uint256(0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_getRoot_unbalanced_sample1() external {
+        uint256 startingIndex_ = 0;
+        uint256 leafCount_ = 1;
+
+        bytes[] memory leaves_ = new bytes[](1);
+
+        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        uint256[] memory proofElements_ = new uint256[](1);
+
+        proofElements_[0] = leafCount_;
+
+        uint256 expectedRoot_ = uint256(0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_getRoot_unbalanced_sample2() external {
+        uint256 startingIndex_ = 4;
+        uint256 leafCount_ = 7;
+
+        bytes[] memory leaves_ = new bytes[](2);
+
+        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+        leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
+
+        uint256[] memory proofElements_ = new uint256[](3);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
+        proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
+
+        uint256 expectedRoot_ = uint256(0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_getRoot_unbalanced_sample3() external {
+        uint256 startingIndex_ = 9;
+        uint256 leafCount_ = 13;
+
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        uint256[] memory proofElements_ = new uint256[](3);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        uint256 expectedRoot_ = uint256(0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_getRoot_unbalanced_sample4() external {
+        uint256 startingIndex_ = 200;
+        uint256 leafCount_ = 324;
+
+        bytes[] memory leaves_ = new bytes[](22);
+
+        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
+        leaves_[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
+        leaves_[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
+        leaves_[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
+        leaves_[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
+        leaves_[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
+        leaves_[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
+        leaves_[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
+        leaves_[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
+        leaves_[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
+        leaves_[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
+        leaves_[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
+        leaves_[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
+        leaves_[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
+        leaves_[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
+        leaves_[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
+        leaves_[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
+        leaves_[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
+        leaves_[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
+        leaves_[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
+        leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
+        leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
+
+        uint256[] memory proofElements_ = new uint256[](7);
+
+        proofElements_[0] = leafCount_;
+        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
+        proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
+        proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
+        proofElements_[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
+        proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
+        proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
+
+        uint256 expectedRoot_ = uint256(0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c);
+
+        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+    }
+
+    function test_bitCount64_invalidBitCount64Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
+        _sequentialMerkleProofs.__bitCount64(uint256(type(uint64).max) + 1);
+    }
+
+    function test_bitCount64() external {
+        assertEq(_sequentialMerkleProofs.__bitCount64(1 >> 1), 0);
+        assertEq(_sequentialMerkleProofs.__bitCount64(uint256(type(uint64).max)), 64);
+
+        for (uint256 i_ = 0; i_ < 64; ++i_) {
+            assertEq(_sequentialMerkleProofs.__bitCount64(1 << i_), 1); // One bit set
+            assertEq(_sequentialMerkleProofs.__bitCount64((1 << i_) - 1), i_); // i_ bits set
+        }
+    }
+
+    function test_roundUpToPowerOf2_invalidRoundUpToPowerOf2Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+        _sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint64).max) + 1);
+    }
+
+    function test_roundUpToPowerOf2() external {
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(0), 1);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(1), 1);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(2), 2);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(3), 4);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(4), 4);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(5), 8);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(6), 8);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(7), 8);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(8), 8);
+
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint64).max)), 1 << 64);
+
+        for (uint256 i_ = 4; i_ < 64; ++i_) {
+            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(1 << i_), 1 << i_); // Exact power of 2
+            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << i_) - 1), 1 << i_); // One less than
+            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << (i_ - 1)) + 1), 1 << i_); // One more than prev
+        }
+    }
+
+    function test_getBalancedLeafCount_noLeaves() external {
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        _sequentialMerkleProofs.__getBalancedLeafCount(0);
+    }
+
+    function test_getBalancedLeafCount_invalidRoundUpToPowerOf2Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+        _sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint64).max) + 1);
+    }
+
+    function test_getBalancedLeafCount() external {
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(1), 2);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(2), 2);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(3), 4);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(4), 4);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(5), 8);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(6), 8);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(7), 8);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(8), 8);
+
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint64).max)), 1 << 64);
+
+        for (uint256 i_ = 4; i_ < 64; ++i_) {
+            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(1 << i_), 1 << i_); // Exact power of 2
+            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << i_) - 1), 1 << i_); // One less than
+            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << (i_ - 1)) + 1), 1 << i_); // One more than prev
+        }
+    }
+
+    function test_getReversedLeafNodesFromLeaves() external {
+        bytes[] memory leaves_ = new bytes[](4);
+
+        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
+        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
+        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
+        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+
+        uint256[] memory reversedLeafNodes_ = _sequentialMerkleProofs.__getReversedLeafNodesFromLeaves(leaves_);
+
+        assertEq(bytes32(reversedLeafNodes_[0]), 0x8613e086c6c42ab3b7027723e29bf61497f3629e0fb0c1b0453c93f053e22a18);
+        assertEq(bytes32(reversedLeafNodes_[1]), 0x09a458689dbd19291ce83007725819f0c69504e282d7669b7d08576162bd7f52);
+        assertEq(bytes32(reversedLeafNodes_[2]), 0x569dab69f958322840fb959938fee8dbc2bde84f55584935a8230303db6aaebd);
+        assertEq(bytes32(reversedLeafNodes_[3]), 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b);
+    }
+}

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -14,125 +14,99 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs = new SequentialMerkleProofsHarness();
     }
 
-    function test_hashLeaf() external {
+    function test_hashLeaf() external view {
         assertEq(
-            bytes32(_sequentialMerkleProofs.__hashLeaf("Hello")),
+            _sequentialMerkleProofs.__hashLeaf("Hello"),
             0x0b8faa8dd08a172ebf9582ef1c73d06a82e28d18c61a8b47b13d01f1740e9a11
         );
 
         assertEq(
-            bytes32(_sequentialMerkleProofs.__hashLeaf("World")),
+            _sequentialMerkleProofs.__hashLeaf("World"),
             0x817d5a47d8f38274199af57907aa20a633a5f767439cfc22e11a5dd5a4493f2a
         );
 
         assertEq(
-            bytes32(_sequentialMerkleProofs.__hashLeaf("Lorem ipsum dolor sit amet")),
+            _sequentialMerkleProofs.__hashLeaf("Lorem ipsum dolor sit amet"),
             0xa5dc43044db877acef8181b04b78a81c39a01d8ba78e29a5fe06a99732e626d3
         );
 
         assertEq(
-            bytes32(_sequentialMerkleProofs.__hashLeaf("Lorem ipsum dolor sit amet consectetur adipiscing elit")),
+            _sequentialMerkleProofs.__hashLeaf("Lorem ipsum dolor sit amet consectetur adipiscing elit"),
             0xa5fe16054246ec55b4c4f376e432cce9f5d7e9c6859bf2801c1d05e0a187341c
         );
     }
 
-    function test_hashNodePair() external {
+    function test_hashNodePair() external view {
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashNodePair(
-                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
-                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
-                )
+            _sequentialMerkleProofs.__hashNodePair(
+                0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
+                0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
             ),
             0x30c08f17fca6d5b183fd798df2c94be55f9191aa17b64e14af24dea51d56a200
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashNodePair(
-                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
-                    0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
-                )
+            _sequentialMerkleProofs.__hashNodePair(
+                0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,
+                0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
             ),
             0xaf45a9d3cd256488928e96458a0fe6bde6182c416dad6228c15900570ad4ce86
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashNodePair(
-                    0x0000000000000000000000000000000000000000000000000000000000000000,
-                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-                )
+            _sequentialMerkleProofs.__hashNodePair(
+                0x0000000000000000000000000000000000000000000000000000000000000000,
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
             ),
             0xcf86af75a8a3ad149001943d69c6f6baf87e648e765e365f9aea84c06a306fea
         );
     }
 
-    function test_hashPairlessNode() external {
+    function test_hashPairlessNode() external view {
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashPairlessNode(
-                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
-                )
+            _sequentialMerkleProofs.__hashPairlessNode(
+                0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
             ),
             0x4bde7d5c3f4483ac1642c0f72078ce38639cca66529ce401be6200d03194f0a5
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashPairlessNode(
-                    0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
-                )
+            _sequentialMerkleProofs.__hashPairlessNode(
+                0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
             ),
             0x26960017dbb60afc80dfcc5a6ccbfa17711de9e934a46ae4532a79ac33344a02
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashPairlessNode(
-                    0x0000000000000000000000000000000000000000000000000000000000000000
-                )
+            _sequentialMerkleProofs.__hashPairlessNode(
+                0x0000000000000000000000000000000000000000000000000000000000000000
             ),
             0xeb14eebf6aaf45d22d20a202b833f1d484603044dea188a8eb1585c22d01a41f
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashPairlessNode(
-                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-                )
+            _sequentialMerkleProofs.__hashPairlessNode(
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
             ),
             0x2f8f0f26e7f767c7dea71e75bf4f70510db5b05f50e842eeb6dc09d678b87640
         );
     }
 
-    function test_hashRoot() external {
+    function test_hashRoot() external view {
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashRoot(
-                    1,
-                    0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
-                )
-            ),
+            _sequentialMerkleProofs.__hashRoot(1, 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f),
             0x42bdfcbf85f7e8aafa85a4c4ce995c0f8413225503d8b5aeaadaa7a044083acb
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashRoot(
-                    78,
-                    0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
-                )
-            ),
+            _sequentialMerkleProofs.__hashRoot(78, 0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100),
             0xda04fbfbac2808039eaf34829fbb30df8855c1589785cb5764e23b1b32fd2537
         );
 
         assertEq(
-            bytes32(
-                _sequentialMerkleProofs.__hashRoot(
-                    46984,
-                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-                )
+            _sequentialMerkleProofs.__hashRoot(
+                46984,
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
             ),
             0x6bd1491b7fd13801bace4086092489a8e34ac0c15920d1ad7921e0f402eae63e
         );
@@ -140,21 +114,21 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_verify_noLeafs() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
-        _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new uint256[](0));
+        _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new bytes32[](0));
     }
 
     function test_verify_invalidRoundUpToPowerOf2Input() external {
         bytes[] memory leaves_ = new bytes[](1);
         leaves_[0] = bytes(hex"00");
 
-        uint256[] memory proofElements_ = new uint256[](1);
-        proofElements_[0] = uint256(type(uint64).max) + 1;
+        bytes32[] memory proofElements_ = new bytes32[](1);
+        proofElements_[0] = bytes32(uint256(type(uint64).max) + 1);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
         _sequentialMerkleProofs.verify(0, 0, leaves_, proofElements_);
     }
 
-    function test_verify_balanced_sample1() external {
+    function test_verify_balanced_sample1() external view {
         uint256 startingIndex_ = 0;
         uint256 leafCount_ = 2;
 
@@ -162,12 +136,12 @@ contract SequentialMerkleProofsTests is Test {
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
 
-        uint256[] memory proofElements_ = new uint256[](2);
+        bytes32[] memory proofElements_ = new bytes32[](2);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
 
-        uint256 root_ = uint256(0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0);
+        bytes32 root_ = 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -180,15 +154,15 @@ contract SequentialMerkleProofsTests is Test {
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
 
-        uint256[] memory proofElements_ = new uint256[](2);
+        bytes32[] memory proofElements_ = new bytes32[](2);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
 
-        uint256 root_ = uint256(0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0);
+        bytes32 root_ = 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -199,19 +173,19 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(stdError.indexOOBError);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59a;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
-    function test_verify_balanced_sample2() external {
+    function test_verify_balanced_sample2() external view {
         uint256 startingIndex_ = 1;
         uint256 leafCount_ = 8;
 
@@ -222,14 +196,14 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
         leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
 
-        uint256[] memory proofElements_ = new uint256[](4);
+        bytes32[] memory proofElements_ = new bytes32[](4);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
         proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
         proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
 
-        uint256 root_ = uint256(0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7);
+        bytes32 root_ = 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -245,17 +219,17 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
         leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
 
-        uint256[] memory proofElements_ = new uint256[](4);
+        bytes32[] memory proofElements_ = new bytes32[](4);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
         proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
         proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
 
-        uint256 root_ = uint256(0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7);
+        bytes32 root_ = 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -266,19 +240,19 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(stdError.indexOOBError);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d86;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
-    function test_verify_balanced_sample3() external {
+    function test_verify_balanced_sample3() external view {
         uint256 startingIndex_ = 9;
         uint256 leafCount_ = 16;
 
@@ -289,15 +263,15 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
         leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
 
-        uint256[] memory proofElements_ = new uint256[](5);
+        bytes32[] memory proofElements_ = new bytes32[](5);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
         proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
         proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
         proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
 
-        uint256 root_ = uint256(0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942);
+        bytes32 root_ = 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -313,18 +287,18 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
         leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
 
-        uint256[] memory proofElements_ = new uint256[](5);
+        bytes32[] memory proofElements_ = new bytes32[](5);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
         proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
         proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
         proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
 
-        uint256 root_ = uint256(0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942);
+        bytes32 root_ = 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -335,19 +309,19 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(stdError.indexOOBError);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d5;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
-    function test_verify_unbalanced_sample1() external {
+    function test_verify_unbalanced_sample1() external view {
         uint256 startingIndex_ = 0;
         uint256 leafCount_ = 1;
 
@@ -355,11 +329,11 @@ contract SequentialMerkleProofsTests is Test {
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
 
-        uint256[] memory proofElements_ = new uint256[](1);
+        bytes32[] memory proofElements_ = new bytes32[](1);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
 
-        uint256 root_ = uint256(0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3);
+        bytes32 root_ = 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -372,14 +346,14 @@ contract SequentialMerkleProofsTests is Test {
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
 
-        uint256[] memory proofElements_ = new uint256[](1);
+        bytes32[] memory proofElements_ = new bytes32[](1);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
 
-        uint256 root_ = uint256(0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3);
+        bytes32 root_ = 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -390,13 +364,13 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(stdError.indexOOBError);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
-    function test_verify_unbalanced_sample2() external {
+    function test_verify_unbalanced_sample2() external view {
         uint256 startingIndex_ = 4;
         uint256 leafCount_ = 7;
 
@@ -405,13 +379,13 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
         leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
 
-        uint256[] memory proofElements_ = new uint256[](3);
+        bytes32[] memory proofElements_ = new bytes32[](3);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
         proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
 
-        uint256 root_ = uint256(0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2);
+        bytes32 root_ = 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -425,16 +399,16 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
         leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
 
-        uint256[] memory proofElements_ = new uint256[](3);
+        bytes32[] memory proofElements_ = new bytes32[](3);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
         proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
 
-        uint256 root_ = uint256(0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2);
+        bytes32 root_ = 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -445,19 +419,19 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de837;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
-    function test_verify_unbalanced_sample3() external {
+    function test_verify_unbalanced_sample3() external view {
         uint256 startingIndex_ = 9;
         uint256 leafCount_ = 13;
 
@@ -468,13 +442,13 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
         leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
 
-        uint256[] memory proofElements_ = new uint256[](3);
+        bytes32[] memory proofElements_ = new bytes32[](3);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
         proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
 
-        uint256 root_ = uint256(0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087);
+        bytes32 root_ = 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -490,16 +464,16 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
         leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
 
-        uint256[] memory proofElements_ = new uint256[](3);
+        bytes32[] memory proofElements_ = new bytes32[](3);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
         proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
 
-        uint256 root_ = uint256(0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087);
+        bytes32 root_ = 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -510,19 +484,19 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(stdError.indexOOBError);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93b;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
-    function test_verify_unbalanced_sample4() external {
+    function test_verify_unbalanced_sample4() external view {
         uint256 startingIndex_ = 200;
         uint256 leafCount_ = 324;
 
@@ -551,9 +525,9 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
         leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
 
-        uint256[] memory proofElements_ = new uint256[](7);
+        bytes32[] memory proofElements_ = new bytes32[](7);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
         proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
         proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
@@ -561,7 +535,7 @@ contract SequentialMerkleProofsTests is Test {
         proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
         proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
 
-        uint256 root_ = uint256(0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c);
+        bytes32 root_ = 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c;
 
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -595,9 +569,9 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
         leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
 
-        uint256[] memory proofElements_ = new uint256[](7);
+        bytes32[] memory proofElements_ = new bytes32[](7);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
         proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
         proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
@@ -605,10 +579,10 @@ contract SequentialMerkleProofsTests is Test {
         proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
         proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
 
-        uint256 root_ = uint256(0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c);
+        bytes32 root_ = 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_ + 1, startingIndex_, leaves_, proofElements_);
+        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
 
         vm.expectRevert(stdError.indexOOBError);
         _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
@@ -619,12 +593,12 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
         leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
-        proofElements_[0] = leafCount_ + 1;
+        proofElements_[0] = bytes32(leafCount_ + 1);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1213;
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
@@ -633,31 +607,31 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_getRoot_noLeaves() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
-        _sequentialMerkleProofs.getRoot(0, new bytes[](0), new uint256[](0));
+        _sequentialMerkleProofs.getRoot(0, new bytes[](0), new bytes32[](0));
     }
 
     function test_getRoot_noProofElements() external {
         vm.expectRevert(SequentialMerkleProofs.NoProofElements.selector);
-        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new uint256[](0));
+        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new bytes32[](0));
     }
 
     function test_getRoot_invalidProof() external {
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new uint256[](1));
+        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new bytes32[](1));
     }
 
     function test_getRoot_invalidRoundUpToPowerOf2Input() external {
         bytes[] memory leaves_ = new bytes[](1);
         leaves_[0] = bytes(hex"00");
 
-        uint256[] memory proofElements_ = new uint256[](1);
-        proofElements_[0] = uint256(type(uint64).max) + 1;
+        bytes32[] memory proofElements_ = new bytes32[](1);
+        proofElements_[0] = bytes32(uint256(type(uint64).max) + 1);
 
         vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
         _sequentialMerkleProofs.getRoot(0, leaves_, proofElements_);
     }
 
-    function test_getRoot_balanced_sample1() external {
+    function test_getRoot_balanced_sample1() external view {
         uint256 startingIndex_ = 0;
         uint256 leafCount_ = 2;
 
@@ -665,17 +639,17 @@ contract SequentialMerkleProofsTests is Test {
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
 
-        uint256[] memory proofElements_ = new uint256[](2);
+        bytes32[] memory proofElements_ = new bytes32[](2);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
 
-        uint256 expectedRoot_ = uint256(0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0);
+        bytes32 expectedRoot_ = 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_getRoot_balanced_sample2() external {
+    function test_getRoot_balanced_sample2() external view {
         uint256 startingIndex_ = 1;
         uint256 leafCount_ = 8;
 
@@ -686,19 +660,19 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
         leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
 
-        uint256[] memory proofElements_ = new uint256[](4);
+        bytes32[] memory proofElements_ = new bytes32[](4);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
         proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
         proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
 
-        uint256 expectedRoot_ = uint256(0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7);
+        bytes32 expectedRoot_ = 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_getRoot_balanced_sample3() external {
+    function test_getRoot_balanced_sample3() external view {
         uint256 startingIndex_ = 9;
         uint256 leafCount_ = 16;
 
@@ -709,20 +683,20 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
         leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
 
-        uint256[] memory proofElements_ = new uint256[](5);
+        bytes32[] memory proofElements_ = new bytes32[](5);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
         proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
         proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
         proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
 
-        uint256 expectedRoot_ = uint256(0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942);
+        bytes32 expectedRoot_ = 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_getRoot_unbalanced_sample1() external {
+    function test_getRoot_unbalanced_sample1() external view {
         uint256 startingIndex_ = 0;
         uint256 leafCount_ = 1;
 
@@ -730,16 +704,16 @@ contract SequentialMerkleProofsTests is Test {
 
         leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
 
-        uint256[] memory proofElements_ = new uint256[](1);
+        bytes32[] memory proofElements_ = new bytes32[](1);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
 
-        uint256 expectedRoot_ = uint256(0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3);
+        bytes32 expectedRoot_ = 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_getRoot_unbalanced_sample2() external {
+    function test_getRoot_unbalanced_sample2() external view {
         uint256 startingIndex_ = 4;
         uint256 leafCount_ = 7;
 
@@ -748,18 +722,18 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
         leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
 
-        uint256[] memory proofElements_ = new uint256[](3);
+        bytes32[] memory proofElements_ = new bytes32[](3);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
         proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
 
-        uint256 expectedRoot_ = uint256(0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2);
+        bytes32 expectedRoot_ = 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_getRoot_unbalanced_sample3() external {
+    function test_getRoot_unbalanced_sample3() external view {
         uint256 startingIndex_ = 9;
         uint256 leafCount_ = 13;
 
@@ -770,18 +744,18 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
         leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
 
-        uint256[] memory proofElements_ = new uint256[](3);
+        bytes32[] memory proofElements_ = new bytes32[](3);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
         proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
 
-        uint256 expectedRoot_ = uint256(0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087);
+        bytes32 expectedRoot_ = 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_getRoot_unbalanced_sample4() external {
+    function test_getRoot_unbalanced_sample4() external view {
         uint256 startingIndex_ = 200;
         uint256 leafCount_ = 324;
 
@@ -810,9 +784,9 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
         leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
 
-        uint256[] memory proofElements_ = new uint256[](7);
+        bytes32[] memory proofElements_ = new bytes32[](7);
 
-        proofElements_[0] = leafCount_;
+        proofElements_[0] = bytes32(leafCount_);
         proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
         proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
         proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
@@ -820,7 +794,7 @@ contract SequentialMerkleProofsTests is Test {
         proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
         proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
 
-        uint256 expectedRoot_ = uint256(0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c);
+        bytes32 expectedRoot_ = 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c;
 
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
@@ -830,7 +804,7 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.__bitCount64(uint256(type(uint64).max) + 1);
     }
 
-    function test_bitCount64() external {
+    function test_bitCount64() external view {
         assertEq(_sequentialMerkleProofs.__bitCount64(1 >> 1), 0);
         assertEq(_sequentialMerkleProofs.__bitCount64(uint256(type(uint64).max)), 64);
 
@@ -845,7 +819,7 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint64).max) + 1);
     }
 
-    function test_roundUpToPowerOf2() external {
+    function test_roundUpToPowerOf2() external view {
         assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(0), 1);
         assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(1), 1);
         assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(2), 2);
@@ -875,7 +849,7 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint64).max) + 1);
     }
 
-    function test_getBalancedLeafCount() external {
+    function test_getBalancedLeafCount() external view {
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(1), 2);
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(2), 2);
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(3), 4);
@@ -894,7 +868,7 @@ contract SequentialMerkleProofsTests is Test {
         }
     }
 
-    function test_getReversedLeafNodesFromLeaves() external {
+    function test_getReversedLeafNodesFromLeaves() external view {
         bytes[] memory leaves_ = new bytes[](4);
 
         leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
@@ -902,11 +876,11 @@ contract SequentialMerkleProofsTests is Test {
         leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
         leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
 
-        uint256[] memory reversedLeafNodes_ = _sequentialMerkleProofs.__getReversedLeafNodesFromLeaves(leaves_);
+        bytes32[] memory reversedLeafNodes_ = _sequentialMerkleProofs.__getReversedLeafNodesFromLeaves(leaves_);
 
-        assertEq(bytes32(reversedLeafNodes_[0]), 0x8613e086c6c42ab3b7027723e29bf61497f3629e0fb0c1b0453c93f053e22a18);
-        assertEq(bytes32(reversedLeafNodes_[1]), 0x09a458689dbd19291ce83007725819f0c69504e282d7669b7d08576162bd7f52);
-        assertEq(bytes32(reversedLeafNodes_[2]), 0x569dab69f958322840fb959938fee8dbc2bde84f55584935a8230303db6aaebd);
-        assertEq(bytes32(reversedLeafNodes_[3]), 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b);
+        assertEq(reversedLeafNodes_[0], 0x8613e086c6c42ab3b7027723e29bf61497f3629e0fb0c1b0453c93f053e22a18);
+        assertEq(reversedLeafNodes_[1], 0x09a458689dbd19291ce83007725819f0c69504e282d7669b7d08576162bd7f52);
+        assertEq(reversedLeafNodes_[2], 0x569dab69f958322840fb959938fee8dbc2bde84f55584935a8230303db6aaebd);
+        assertEq(reversedLeafNodes_[3], 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b);
     }
 }

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -8,10 +8,24 @@ import { SequentialMerkleProofs } from "../../src/libraries/SequentialMerkleProo
 import { SequentialMerkleProofsHarness } from "../utils/Harnesses.sol";
 
 contract SequentialMerkleProofsTests is Test {
+    struct Sample {
+        uint256 startingIndex;
+        uint256 leafCount;
+        bytes[] leaves;
+        bytes32[] proofElements;
+        bytes32 root;
+    }
+
+    Sample[] internal _balancedSamples;
+    Sample[] internal _unbalancedSamples;
+
     SequentialMerkleProofsHarness internal _sequentialMerkleProofs;
 
     function setUp() external {
         _sequentialMerkleProofs = new SequentialMerkleProofsHarness();
+
+        _buildBalancedSamples();
+        _buildUnbalancedSamples();
     }
 
     /* ============ hashLeaf ============ */
@@ -155,481 +169,50 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new bytes32[](1));
     }
 
-    function test_verify_balanced_sample1() external view {
-        uint256 startingIndex_ = 0;
-        uint256 leafCount_ = 2;
-
-        bytes[] memory leaves_ = new bytes[](1);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-
-        bytes32[] memory proofElements_ = new bytes32[](2);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
-
-        bytes32 root_ = 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    function test_verify_balancedSamples() external view {
+        for (uint256 index_; index_ < _balancedSamples.length; ++index_) {
+            Sample storage sample_ = _balancedSamples[0];
+            _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+        }
     }
 
-    function test_verify_balanced_sample1_invalidProof() external {
-        uint256 startingIndex_ = 0;
-        uint256 leafCount_ = 2;
+    function test_verify_balancedSamples_invalidProofs() external {
+        for (uint256 index_; index_ < _balancedSamples.length; ++index_) {
+            Sample storage sample_ = _balancedSamples[index_];
 
-        bytes[] memory leaves_ = new bytes[](1);
+            _testVerifyWithIncorrectRoot(sample_);
+            _testVerifyWithIncorrectStartingIndex(sample_);
+            _testVerifyWithOutOfBoundsStartingIndex(sample_);
+            _testVerifyWithIncorrectLeaf(sample_);
+            _testVerifyWithIncorrectLeafCount(sample_);
 
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+            if (sample_.proofElements.length == 1) continue;
 
-        bytes32[] memory proofElements_ = new bytes32[](2);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
-
-        bytes32 root_ = 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd1");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(stdError.indexOOBError);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59a;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+            _testVerifyWithIncorrectProofElement(sample_);
+        }
     }
 
-    function test_verify_balanced_sample2() external view {
-        uint256 startingIndex_ = 1;
-        uint256 leafCount_ = 8;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
-        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
-        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
-        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-
-        bytes32[] memory proofElements_ = new bytes32[](4);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
-        proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
-        proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
-
-        bytes32 root_ = 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    function test_verify_unbalancedSamples() external view {
+        for (uint256 index_; index_ < _unbalancedSamples.length; ++index_) {
+            Sample storage sample_ = _unbalancedSamples[0];
+            _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+        }
     }
 
-    function test_verify_balanced_sample2_invalidProof() external {
-        uint256 startingIndex_ = 1;
-        uint256 leafCount_ = 8;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
-        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
-        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
-        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-
-        bytes32[] memory proofElements_ = new bytes32[](4);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
-        proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
-        proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
-
-        bytes32 root_ = 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee32");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(stdError.indexOOBError);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d86;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_balanced_sample3() external view {
-        uint256 startingIndex_ = 9;
-        uint256 leafCount_ = 16;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
-        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
-        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
-
-        bytes32[] memory proofElements_ = new bytes32[](5);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
-        proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
-        proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
-        proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
-
-        bytes32 root_ = 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_balanced_sample3_invalidProof() external {
-        uint256 startingIndex_ = 9;
-        uint256 leafCount_ = 16;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
-        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
-        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
-
-        bytes32[] memory proofElements_ = new bytes32[](5);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
-        proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
-        proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
-        proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
-
-        bytes32 root_ = 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b3");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(stdError.indexOOBError);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d5;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample1() external view {
-        uint256 startingIndex_ = 0;
-        uint256 leafCount_ = 1;
-
-        bytes[] memory leaves_ = new bytes[](1);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-
-        bytes32[] memory proofElements_ = new bytes32[](1);
-
-        proofElements_[0] = bytes32(leafCount_);
-
-        bytes32 root_ = 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample1_invalidProof() external {
-        uint256 startingIndex_ = 0;
-        uint256 leafCount_ = 1;
-
-        bytes[] memory leaves_ = new bytes[](1);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-
-        bytes32[] memory proofElements_ = new bytes32[](1);
-
-        proofElements_[0] = bytes32(leafCount_);
-
-        bytes32 root_ = 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd3");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(stdError.indexOOBError);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample2() external view {
-        uint256 startingIndex_ = 4;
-        uint256 leafCount_ = 7;
-
-        bytes[] memory leaves_ = new bytes[](2);
-
-        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-        leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
-
-        bytes32[] memory proofElements_ = new bytes32[](3);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
-        proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
-
-        bytes32 root_ = 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample2_invalidProof() external {
-        uint256 startingIndex_ = 4;
-        uint256 leafCount_ = 7;
-
-        bytes[] memory leaves_ = new bytes[](2);
-
-        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-        leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
-
-        bytes32[] memory proofElements_ = new bytes32[](3);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
-        proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
-
-        bytes32 root_ = 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c68");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de837;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample3() external view {
-        uint256 startingIndex_ = 9;
-        uint256 leafCount_ = 13;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
-        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
-        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
-
-        bytes32[] memory proofElements_ = new bytes32[](3);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
-        proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
-
-        bytes32 root_ = 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample3_invalidProof() external {
-        uint256 startingIndex_ = 9;
-        uint256 leafCount_ = 13;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
-        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
-        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
-
-        bytes32[] memory proofElements_ = new bytes32[](3);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
-        proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
-
-        bytes32 root_ = 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b3");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(stdError.indexOOBError);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93b;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample4() external view {
-        uint256 startingIndex_ = 200;
-        uint256 leafCount_ = 324;
-
-        bytes[] memory leaves_ = new bytes[](22);
-
-        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
-        leaves_[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
-        leaves_[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
-        leaves_[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
-        leaves_[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
-        leaves_[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
-        leaves_[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
-        leaves_[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
-        leaves_[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
-        leaves_[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
-        leaves_[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
-        leaves_[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
-        leaves_[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
-        leaves_[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
-        leaves_[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
-        leaves_[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
-        leaves_[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
-        leaves_[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
-        leaves_[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
-        leaves_[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
-        leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
-        leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
-
-        bytes32[] memory proofElements_ = new bytes32[](7);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
-        proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
-        proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
-        proofElements_[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
-        proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
-        proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
-
-        bytes32 root_ = 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c;
-
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-    }
-
-    function test_verify_unbalanced_sample4_invalidProof() external {
-        uint256 startingIndex_ = 200;
-        uint256 leafCount_ = 324;
-
-        bytes[] memory leaves_ = new bytes[](22);
-
-        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
-        leaves_[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
-        leaves_[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
-        leaves_[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
-        leaves_[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
-        leaves_[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
-        leaves_[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
-        leaves_[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
-        leaves_[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
-        leaves_[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
-        leaves_[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
-        leaves_[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
-        leaves_[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
-        leaves_[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
-        leaves_[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
-        leaves_[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
-        leaves_[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
-        leaves_[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
-        leaves_[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
-        leaves_[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
-        leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
-        leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
-
-        bytes32[] memory proofElements_ = new bytes32[](7);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
-        proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
-        proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
-        proofElements_[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
-        proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
-        proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
-
-        bytes32 root_ = 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(bytes32(uint256(root_) + 1), startingIndex_, leaves_, proofElements_);
-
-        vm.expectRevert(stdError.indexOOBError);
-        _sequentialMerkleProofs.verify(root_, startingIndex_ + 1, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3e");
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
-        proofElements_[0] = bytes32(leafCount_ + 1);
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1213;
-
-        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
-        _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    function test_verify_unbalancedSamples_invalidProofs() external {
+        for (uint256 index_; index_ < _unbalancedSamples.length; ++index_) {
+            Sample storage sample_ = _unbalancedSamples[index_];
+
+            _testVerifyWithIncorrectRoot(sample_);
+            _testVerifyWithIncorrectStartingIndex(sample_);
+            _testVerifyWithOutOfBoundsStartingIndex(sample_);
+            _testVerifyWithIncorrectLeaf(sample_);
+            _testVerifyWithIncorrectLeafCount(sample_);
+
+            if (sample_.proofElements.length == 1) continue;
+
+            _testVerifyWithIncorrectProofElement(sample_);
+        }
     }
 
     /* ============ getRoot ============ */
@@ -641,7 +224,7 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_getRoot_noLeafs_nonZeroStartingIndex() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
-        (_sequentialMerkleProofs.getRoot(1, new bytes[](0), new bytes32[](1)));
+        _sequentialMerkleProofs.getRoot(1, new bytes[](0), new bytes32[](1));
     }
 
     function test_getRoot_noLeafs_nonZeroLeafCount() external {
@@ -672,172 +255,26 @@ contract SequentialMerkleProofsTests is Test {
         assertEq(_sequentialMerkleProofs.getRoot(0, new bytes[](0), new bytes32[](1)), bytes32(0));
     }
 
-    function test_getRoot_balanced_sample1() external view {
-        uint256 startingIndex_ = 0;
-        uint256 leafCount_ = 2;
+    function test_getRoot_balancedSamples() external view {
+        for (uint256 index_; index_ < _balancedSamples.length; ++index_) {
+            Sample storage sample_ = _balancedSamples[0];
 
-        bytes[] memory leaves_ = new bytes[](1);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-
-        bytes32[] memory proofElements_ = new bytes32[](2);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b;
-
-        bytes32 expectedRoot_ = 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+            assertEq(
+                _sequentialMerkleProofs.getRoot(sample_.startingIndex, sample_.leaves, sample_.proofElements),
+                sample_.root
+            );
+        }
     }
 
-    function test_getRoot_balanced_sample2() external view {
-        uint256 startingIndex_ = 1;
-        uint256 leafCount_ = 8;
+    function test_getRoot_unbalancedSamples() external view {
+        for (uint256 index_; index_ < _unbalancedSamples.length; ++index_) {
+            Sample storage sample_ = _unbalancedSamples[0];
 
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
-        leaves_[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
-        leaves_[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
-        leaves_[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-
-        bytes32[] memory proofElements_ = new bytes32[](4);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
-        proofElements_[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
-        proofElements_[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
-
-        bytes32 expectedRoot_ = 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
-    }
-
-    function test_getRoot_balanced_sample3() external view {
-        uint256 startingIndex_ = 9;
-        uint256 leafCount_ = 16;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
-        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
-        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
-
-        bytes32[] memory proofElements_ = new bytes32[](5);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
-        proofElements_[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
-        proofElements_[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
-        proofElements_[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
-
-        bytes32 expectedRoot_ = 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
-    }
-
-    function test_getRoot_unbalanced_sample1() external view {
-        uint256 startingIndex_ = 0;
-        uint256 leafCount_ = 1;
-
-        bytes[] memory leaves_ = new bytes[](1);
-
-        leaves_[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
-
-        bytes32[] memory proofElements_ = new bytes32[](1);
-
-        proofElements_[0] = bytes32(leafCount_);
-
-        bytes32 expectedRoot_ = 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
-    }
-
-    function test_getRoot_unbalanced_sample2() external view {
-        uint256 startingIndex_ = 4;
-        uint256 leafCount_ = 7;
-
-        bytes[] memory leaves_ = new bytes[](2);
-
-        leaves_[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
-        leaves_[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
-
-        bytes32[] memory proofElements_ = new bytes32[](3);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
-        proofElements_[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
-
-        bytes32 expectedRoot_ = 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
-    }
-
-    function test_getRoot_unbalanced_sample3() external view {
-        uint256 startingIndex_ = 9;
-        uint256 leafCount_ = 13;
-
-        bytes[] memory leaves_ = new bytes[](4);
-
-        leaves_[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
-        leaves_[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
-        leaves_[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
-        leaves_[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
-
-        bytes32[] memory proofElements_ = new bytes32[](3);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
-        proofElements_[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
-
-        bytes32 expectedRoot_ = 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
-    }
-
-    function test_getRoot_unbalanced_sample4() external view {
-        uint256 startingIndex_ = 200;
-        uint256 leafCount_ = 324;
-
-        bytes[] memory leaves_ = new bytes[](22);
-
-        leaves_[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
-        leaves_[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
-        leaves_[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
-        leaves_[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
-        leaves_[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
-        leaves_[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
-        leaves_[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
-        leaves_[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
-        leaves_[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
-        leaves_[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
-        leaves_[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
-        leaves_[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
-        leaves_[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
-        leaves_[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
-        leaves_[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
-        leaves_[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
-        leaves_[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
-        leaves_[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
-        leaves_[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
-        leaves_[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
-        leaves_[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
-        leaves_[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
-
-        bytes32[] memory proofElements_ = new bytes32[](7);
-
-        proofElements_[0] = bytes32(leafCount_);
-        proofElements_[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
-        proofElements_[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
-        proofElements_[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
-        proofElements_[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
-        proofElements_[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
-        proofElements_[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
-
-        bytes32 expectedRoot_ = 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c;
-
-        assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
+            assertEq(
+                _sequentialMerkleProofs.getRoot(sample_.startingIndex, sample_.leaves, sample_.proofElements),
+                sample_.root
+            );
+        }
     }
 
     /* ============ bitCount32 ============ */
@@ -848,7 +285,7 @@ contract SequentialMerkleProofsTests is Test {
     }
 
     function test_bitCount32() external view {
-        assertEq(_sequentialMerkleProofs.__bitCount32(1 >> 1), 0);
+        assertEq(_sequentialMerkleProofs.__bitCount32(0), 0);
         assertEq(_sequentialMerkleProofs.__bitCount32(uint256(type(uint32).max)), 32);
 
         for (uint256 i_ = 0; i_ < 32; ++i_) {
@@ -927,5 +364,232 @@ contract SequentialMerkleProofsTests is Test {
         assertEq(reversedLeafNodes_[1], 0x09a458689dbd19291ce83007725819f0c69504e282d7669b7d08576162bd7f52);
         assertEq(reversedLeafNodes_[2], 0x569dab69f958322840fb959938fee8dbc2bde84f55584935a8230303db6aaebd);
         assertEq(reversedLeafNodes_[3], 0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b);
+    }
+
+    /* ============ helpers ============ */
+
+    function _buildBalancedSamples() internal {
+        /* ============ Sample 1 ============ */
+
+        _balancedSamples.push(
+            Sample({
+                startingIndex: 0,
+                leafCount: 2,
+                leaves: new bytes[](1),
+                proofElements: new bytes32[](2),
+                root: 0xeeef536868dc2c030bec2d3602cc13fbe660bd5d63deca6a0a4dfd201eb941c0
+            })
+        );
+
+        _balancedSamples[0].leaves[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        _balancedSamples[0].proofElements[0] = bytes32(_balancedSamples[0].leafCount);
+        _balancedSamples[0].proofElements[1] = bytes32(
+            0xb8283b9a33ca222061b7d8d5f85170289c5c4a7f96997ce2ae5bafc94fc8a59b
+        );
+
+        /* ============ Sample 2 ============ */
+
+        _balancedSamples.push(
+            Sample({
+                startingIndex: 1,
+                leafCount: 8,
+                leaves: new bytes[](4),
+                proofElements: new bytes32[](4),
+                root: 0x00f8c0ad3c60c727ededce5717c8baa64047b5c3f29e409085df14dc3bfda1a7
+            })
+        );
+
+        _balancedSamples[1].leaves[0] = bytes(hex"a8152e7c56b62d9fcb8af361257a260b2b9481c8683e8df1651a31508cc6ee31");
+        _balancedSamples[1].leaves[1] = bytes(hex"007f47e1c51d53cab18977050347e8e8dc488bdd9590babe3e104fcb9a1ef599");
+        _balancedSamples[1].leaves[2] = bytes(hex"7cbe68a29af312d42c40e6d083bb64fe2ba0ac6bf1cac8e4b10f5356142e3828");
+        _balancedSamples[1].leaves[3] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+
+        _balancedSamples[1].proofElements[0] = bytes32(_balancedSamples[1].leafCount);
+        _balancedSamples[1].proofElements[1] = 0xb7f40118daf8bbb92b1759e810c6eb4b0b92e04d1b7e4be48a147721ea457d87;
+        _balancedSamples[1].proofElements[2] = 0x06331c9b61be683c1819b2cd20c83f315499477f6253ae8d8bb02cbc6bd93c9f;
+        _balancedSamples[1].proofElements[3] = 0xc3d064e0f1ace0f92e6c822d5346de5330fb23a6c31a0c84a80d9d5c8543cc0e;
+
+        /* ============ Sample 3 ============ */
+
+        _balancedSamples.push(
+            Sample({
+                startingIndex: 9,
+                leafCount: 16,
+                leaves: new bytes[](4),
+                proofElements: new bytes32[](5),
+                root: 0x31338b156e26447f0a3a965981b0be87957bf5606b44e0dcdc99eb4646048942
+            })
+        );
+
+        _balancedSamples[2].leaves[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        _balancedSamples[2].leaves[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        _balancedSamples[2].leaves[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        _balancedSamples[2].leaves[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        _balancedSamples[2].proofElements[0] = bytes32(_balancedSamples[2].leafCount);
+        _balancedSamples[2].proofElements[1] = 0x194f8cb59bc03a6e9dfcc3566bed0a85a069f50de609f51af6c74dee673450d4;
+        _balancedSamples[2].proofElements[2] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        _balancedSamples[2].proofElements[3] = 0x9d8799ecccbca75f60304876c8426007565302fdb72449fe980917d7847d43e7;
+        _balancedSamples[2].proofElements[4] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+    }
+
+    function _buildUnbalancedSamples() internal {
+        /* ============ Sample 1 ============ */
+
+        _unbalancedSamples.push(
+            Sample({
+                startingIndex: 0,
+                leafCount: 1,
+                leaves: new bytes[](1),
+                proofElements: new bytes32[](1),
+                root: 0x5b833bdf4f55e39d1838653841d4a2c651a71b5626b7936e1bedb5212cae96e3
+            })
+        );
+
+        _unbalancedSamples[0].leaves[0] = bytes(hex"6330b989705733cc5c1f7285b8a5b892e08be86ed6fbe9d254713a4277bc5bd2");
+
+        _unbalancedSamples[0].proofElements[0] = bytes32(_unbalancedSamples[0].leafCount);
+
+        /* ============ Sample 2 ============ */
+
+        _unbalancedSamples.push(
+            Sample({
+                startingIndex: 4,
+                leafCount: 7,
+                leaves: new bytes[](2),
+                proofElements: new bytes32[](3),
+                root: 0x38631dd8b5081555ec3c51cc8db7918ee90158fa33a70674c1399234d23908b2
+            })
+        );
+
+        _unbalancedSamples[1].leaves[0] = bytes(hex"4a864e860c0d0247c6aa5ebcb2bc3f15fc4ddf86213258f4bf0b72e51c9d9c69");
+        _unbalancedSamples[1].leaves[1] = bytes(hex"51b7ae2bab96bd3fbb3b26e1efefb0b9b6a60054ed7ffcfa700374d58f315a31");
+
+        _unbalancedSamples[1].proofElements[0] = bytes32(_unbalancedSamples[1].leafCount);
+        _unbalancedSamples[1].proofElements[1] = 0x6b379ab3dd3b0b8df76cbe09e2a04f21ebf601f2932d3505ecfb89417f3de836;
+        _unbalancedSamples[1].proofElements[2] = 0x52bd35868bccc1b1f4c3ac67dd7e3b3db4a24f60436411162d633e6d1118de89;
+
+        /* ============ Sample 3 ============ */
+
+        _unbalancedSamples.push(
+            Sample({
+                startingIndex: 9,
+                leafCount: 13,
+                leaves: new bytes[](4),
+                proofElements: new bytes32[](3),
+                root: 0xf92d4ca528834b0350cecd9307bec2dd97d0a6bbb58b077ab51cdad36fc5c087
+            })
+        );
+
+        _unbalancedSamples[2].leaves[0] = bytes(hex"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+        _unbalancedSamples[2].leaves[1] = bytes(hex"112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00");
+        _unbalancedSamples[2].leaves[2] = bytes(hex"f0e1d2c3b4a5968778695a4b3c2d1e0f1f2e3d4c5b6a79887766554433221100");
+        _unbalancedSamples[2].leaves[3] = bytes(hex"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+        _unbalancedSamples[2].proofElements[0] = bytes32(_unbalancedSamples[2].leafCount);
+        _unbalancedSamples[2].proofElements[1] = 0x2642cf6153e4ddfd7ea9c1c99d86efe99c03d29bce0ce4adbf7c0162865aa93a;
+        _unbalancedSamples[2].proofElements[2] = 0x1f70e7dd11a042e3868e8b0992118a3d7bd301b029a3b967a5b2042466c5110c;
+
+        /* ============ Sample 4 ============ */
+
+        _unbalancedSamples.push(
+            Sample({
+                startingIndex: 200,
+                leafCount: 324,
+                leaves: new bytes[](22),
+                proofElements: new bytes32[](7),
+                root: 0x8f28d0f19d1805a3b539bcc2bb0e627ded4bf5b873bebc9199ed179a30ca312c
+            })
+        );
+
+        _unbalancedSamples[3].leaves[0] = bytes(hex"fe0403dd500c862ddbbb4736c071a575d9fd43fbdeea602833234e9cd198bb3f");
+        _unbalancedSamples[3].leaves[1] = bytes(hex"5129d77889ad52ef899ba3d85e01a6df5c230804ccc586faa7e8376b89aa0600");
+        _unbalancedSamples[3].leaves[2] = bytes(hex"f1d6a296210c112eda6ca002273abc7d21b933cf99ca0c8292e344ba2d62f750");
+        _unbalancedSamples[3].leaves[3] = bytes(hex"907f141e1702157a9ca13881b0ecb0cb10be9b588bd6499479496965ce933225");
+        _unbalancedSamples[3].leaves[4] = bytes(hex"c77ccc18e17ec5d50bbbf775f564debfa1f9da8031be2fc7ce618cea8a625226");
+        _unbalancedSamples[3].leaves[5] = bytes(hex"aad8eb018edb0690bbdcebe48db820a6a13e3f8102bb0e5535fdfed79eaa5c39");
+        _unbalancedSamples[3].leaves[6] = bytes(hex"374346003edf10ea2da568e8e973857ec4291bf10a8bf81612b36efaf6e93c23");
+        _unbalancedSamples[3].leaves[7] = bytes(hex"45a3c2e32a3c8ea5e34562806f8279e85cfad69f6015588b599dc2e774d50cee");
+        _unbalancedSamples[3].leaves[8] = bytes(hex"9322c7cbfb342280d72d4eba15c0d9711e3f730072375bc4b0cf538970014e7a");
+        _unbalancedSamples[3].leaves[9] = bytes(hex"b3017e1b1874f68c4508c0b147a4f2b96dd166274c81bb4a86082d391efad6fa");
+        _unbalancedSamples[3].leaves[10] = bytes(hex"76d7f81c6813544dc594db8b5f3d6cef292e91d02a50ad556e6bcddc1eb59f8c");
+        _unbalancedSamples[3].leaves[11] = bytes(hex"320cfee2fb238c49255d102213b395963c2a3ebd7a8ee424e8df02b01361e484");
+        _unbalancedSamples[3].leaves[12] = bytes(hex"697fa39a1e23106c54eeecf38d213bfe2fcf896f55b790815085241b7e7e7361");
+        _unbalancedSamples[3].leaves[13] = bytes(hex"510fde4a04ecbe4bf94a514ab836074270959d2b96492a56909706de0b0248be");
+        _unbalancedSamples[3].leaves[14] = bytes(hex"5fa7828c8c661f4243c97527d637bf318e5e801dcf3b488f0f302622abdf61e9");
+        _unbalancedSamples[3].leaves[15] = bytes(hex"6f7fafb63e26bafeb5fd21a76615d0f2b45e6684324e294f10078661c00b4026");
+        _unbalancedSamples[3].leaves[16] = bytes(hex"e80b189bd7a1e5d0a04d9ba778d11f1bbffec4e276f502780a97fc7006715ac5");
+        _unbalancedSamples[3].leaves[17] = bytes(hex"25e66cd82e8fa7b6072d7759d2b49d0979bad20b018c730f4d1fcac7a6959bd4");
+        _unbalancedSamples[3].leaves[18] = bytes(hex"0695e86d43e2c5097acd182042d09cda438fc1f773335ce0f190dbed668ff508");
+        _unbalancedSamples[3].leaves[19] = bytes(hex"783eb995b1a99bb4181dad1c386dff06c5c02469a4893ca8c0a5b5fd82f7747a");
+        _unbalancedSamples[3].leaves[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
+        _unbalancedSamples[3].leaves[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
+
+        _unbalancedSamples[3].proofElements[0] = bytes32(_unbalancedSamples[2].leafCount);
+        _unbalancedSamples[3].proofElements[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
+        _unbalancedSamples[3].proofElements[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
+        _unbalancedSamples[3].proofElements[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
+        _unbalancedSamples[3].proofElements[4] = 0x25171fda9d5059c4cc4b8a86af5e0634dd8217cd2167c8d868733eef3f23054f;
+        _unbalancedSamples[3].proofElements[5] = 0x1e3106cd69a1fec956fa702eae218bdba94f7150d87c05210b282e334218d265;
+        _unbalancedSamples[3].proofElements[6] = 0xd2b4a539a1349d2d145fe307c30ce5bd43fa10887ce20a8a71da53300c0a6150;
+    }
+
+    function _testVerifyWithIncorrectRoot(Sample storage sample_) internal {
+        sample_.root = bytes32(uint256(sample_.root) + 1);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+
+        sample_.root = bytes32(uint256(sample_.root) - 1);
+    }
+
+    function _testVerifyWithIncorrectStartingIndex(Sample storage sample_) internal {
+        sample_.startingIndex += 1;
+
+        vm.expectRevert();
+        _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+
+        sample_.startingIndex -= 1;
+    }
+
+    function _testVerifyWithOutOfBoundsStartingIndex(Sample storage sample_) internal {
+        uint256 originalStartingIndex_ = sample_.startingIndex;
+
+        sample_.startingIndex = sample_.leafCount + 1;
+
+        vm.expectRevert();
+        _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+
+        sample_.startingIndex = originalStartingIndex_;
+    }
+
+    function _testVerifyWithIncorrectLeaf(Sample storage sample_) internal {
+        bytes memory originalLeaf_ = sample_.leaves[0];
+
+        sample_.leaves[0] = bytes(hex"0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+
+        sample_.leaves[0] = originalLeaf_;
+    }
+
+    function _testVerifyWithIncorrectLeafCount(Sample storage sample_) internal {
+        sample_.proofElements[0] = bytes32(uint256(sample_.proofElements[0]) + 1);
+
+        vm.expectRevert();
+        _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+
+        sample_.proofElements[0] = bytes32(uint256(sample_.proofElements[0]) - 1);
+    }
+
+    function _testVerifyWithIncorrectProofElement(Sample storage sample_) internal {
+        sample_.proofElements[1] = bytes32(uint256(sample_.proofElements[1]) + 1);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
+        _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
+
+        sample_.proofElements[1] = bytes32(uint256(sample_.proofElements[1]) - 1);
     }
 }

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -171,7 +171,7 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_verify_balancedSamples() external view {
         for (uint256 index_; index_ < _balancedSamples.length; ++index_) {
-            Sample storage sample_ = _balancedSamples[0];
+            Sample storage sample_ = _balancedSamples[index_];
             _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
         }
     }
@@ -194,7 +194,7 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_verify_unbalancedSamples() external view {
         for (uint256 index_; index_ < _unbalancedSamples.length; ++index_) {
-            Sample storage sample_ = _unbalancedSamples[0];
+            Sample storage sample_ = _unbalancedSamples[index_];
             _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
         }
     }
@@ -257,7 +257,7 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_getRoot_balancedSamples() external view {
         for (uint256 index_; index_ < _balancedSamples.length; ++index_) {
-            Sample storage sample_ = _balancedSamples[0];
+            Sample storage sample_ = _balancedSamples[index_];
 
             assertEq(
                 _sequentialMerkleProofs.getRoot(sample_.startingIndex, sample_.leaves, sample_.proofElements),
@@ -268,7 +268,7 @@ contract SequentialMerkleProofsTests is Test {
 
     function test_getRoot_unbalancedSamples() external view {
         for (uint256 index_; index_ < _unbalancedSamples.length; ++index_) {
-            Sample storage sample_ = _unbalancedSamples[0];
+            Sample storage sample_ = _unbalancedSamples[index_];
 
             assertEq(
                 _sequentialMerkleProofs.getRoot(sample_.startingIndex, sample_.leaves, sample_.proofElements),
@@ -555,7 +555,7 @@ contract SequentialMerkleProofsTests is Test {
         _unbalancedSamples[3].leaves[20] = bytes(hex"44fb0e55a04f4d5accd7a9e00fd5bbbf8926083ef169c0711f503ae16b589c20");
         _unbalancedSamples[3].leaves[21] = bytes(hex"2815ef424dd0613d69f70546821ebddf2fe1b7452510cd21d25f3e438863e8a3");
 
-        _unbalancedSamples[3].proofElements[0] = bytes32(_unbalancedSamples[2].leafCount);
+        _unbalancedSamples[3].proofElements[0] = bytes32(_unbalancedSamples[3].leafCount);
         _unbalancedSamples[3].proofElements[1] = 0x55f9b393403d39fdf3b35fe8f394e13a272509df05d5562e5da6937c11bb1214;
         _unbalancedSamples[3].proofElements[2] = 0xa4c0ad363d17cb84be9e3f757278de2b26843e918e48e33e1b00438764fefa2b;
         _unbalancedSamples[3].proofElements[3] = 0xafee522c5ba27318361dd426e355fa02e5821fbc8b2ba52dea3b36885d76ec94;
@@ -565,32 +565,44 @@ contract SequentialMerkleProofsTests is Test {
     }
 
     function _testVerifyWithIncorrectRoot(Sample storage sample_) internal {
-        sample_.root = bytes32(uint256(sample_.root) + 1);
+        unchecked {
+            sample_.root = bytes32(uint256(sample_.root) + 1);
+        }
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
 
-        sample_.root = bytes32(uint256(sample_.root) - 1);
+        unchecked {
+            sample_.root = bytes32(uint256(sample_.root) - 1);
+        }
     }
 
     function _testVerifyWithIncorrectStartingIndex(Sample storage sample_) internal {
-        sample_.startingIndex += 1;
+        unchecked {
+            sample_.startingIndex += 1;
+        }
 
         vm.expectRevert();
         _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
 
-        sample_.startingIndex -= 1;
+        unchecked {
+            sample_.startingIndex -= 1;
+        }
     }
 
     function _testVerifyWithOutOfBoundsStartingIndex(Sample storage sample_) internal {
         uint256 originalStartingIndex_ = sample_.startingIndex;
 
-        sample_.startingIndex = sample_.leafCount + 1;
+        unchecked {
+            sample_.startingIndex = sample_.leafCount + 1;
+        }
 
         vm.expectRevert();
         _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
 
-        sample_.startingIndex = originalStartingIndex_;
+        unchecked {
+            sample_.startingIndex = originalStartingIndex_;
+        }
     }
 
     function _testVerifyWithIncorrectLeaf(Sample storage sample_) internal {
@@ -605,20 +617,28 @@ contract SequentialMerkleProofsTests is Test {
     }
 
     function _testVerifyWithIncorrectLeafCount(Sample storage sample_) internal {
-        sample_.proofElements[0] = bytes32(uint256(sample_.proofElements[0]) + 1);
+        unchecked {
+            sample_.proofElements[0] = bytes32(uint256(sample_.proofElements[0]) + 1);
+        }
 
         vm.expectRevert();
         _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
 
-        sample_.proofElements[0] = bytes32(uint256(sample_.proofElements[0]) - 1);
+        unchecked {
+            sample_.proofElements[0] = bytes32(uint256(sample_.proofElements[0]) - 1);
+        }
     }
 
     function _testVerifyWithIncorrectProofElement(Sample storage sample_) internal {
-        sample_.proofElements[1] = bytes32(uint256(sample_.proofElements[1]) + 1);
+        unchecked {
+            sample_.proofElements[1] = bytes32(uint256(sample_.proofElements[1]) + 1);
+        }
 
         vm.expectRevert(SequentialMerkleProofs.InvalidProof.selector);
         _sequentialMerkleProofs.verify(sample_.root, sample_.startingIndex, sample_.leaves, sample_.proofElements);
 
-        sample_.proofElements[1] = bytes32(uint256(sample_.proofElements[1]) - 1);
+        unchecked {
+            sample_.proofElements[1] = bytes32(uint256(sample_.proofElements[1]) - 1);
+        }
     }
 }

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -277,6 +277,35 @@ contract SequentialMerkleProofsTests is Test {
         }
     }
 
+    /* ============ getLeafCount ============ */
+
+    function test_getLeafCount_noProofElements() external {
+        vm.expectRevert(SequentialMerkleProofs.NoProofElements.selector);
+        _sequentialMerkleProofs.getLeafCount(new bytes32[](0));
+    }
+
+    function test_getLeafCount_invalidLeafCount() external {
+        bytes32[] memory proofElements_ = new bytes32[](1);
+        proofElements_[0] = bytes32(uint256(type(uint32).max) + 1);
+
+        vm.expectRevert(SequentialMerkleProofs.InvalidLeafCount.selector);
+        _sequentialMerkleProofs.getLeafCount(proofElements_);
+    }
+
+    function test_getLeafCount() external view {
+        bytes32[] memory proofElements_ = new bytes32[](1);
+
+        assertEq(_sequentialMerkleProofs.getLeafCount(proofElements_), 0);
+
+        proofElements_[0] = bytes32(uint256(1));
+
+        assertEq(_sequentialMerkleProofs.getLeafCount(proofElements_), 1);
+
+        proofElements_[0] = bytes32(uint256(1111));
+
+        assertEq(_sequentialMerkleProofs.getLeafCount(proofElements_), 1111);
+    }
+
     /* ============ bitCount32 ============ */
 
     function test_bitCount32_invalidBitCount32Input() external {

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -122,9 +122,22 @@ contract SequentialMerkleProofsTests is Test {
 
     /* ============ verify ============ */
 
-    function test_verify_noLeafs() external {
-        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+    function test_verify_noProofElements() external {
+        vm.expectRevert(SequentialMerkleProofs.NoProofElements.selector);
         _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new bytes32[](0));
+    }
+
+    function test_verify_noLeafs_nonZeroStartingIndex() external {
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        _sequentialMerkleProofs.verify(0, 1, new bytes[](0), new bytes32[](1));
+    }
+
+    function test_verify_noLeafs_nonZeroLeafCount() external {
+        bytes32[] memory proofElements_ = new bytes32[](1);
+        proofElements_[0] = bytes32(uint256(1));
+
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        _sequentialMerkleProofs.verify(0, 0, new bytes[](0), proofElements_);
     }
 
     function test_verify_invalidBitCount32Input() external {
@@ -136,6 +149,10 @@ contract SequentialMerkleProofsTests is Test {
 
         vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
         _sequentialMerkleProofs.verify(0, 0, leaves_, proofElements_);
+    }
+
+    function test_verify_noLeafs() external {
+        _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new bytes32[](1));
     }
 
     function test_verify_balanced_sample1() external view {
@@ -617,14 +634,22 @@ contract SequentialMerkleProofsTests is Test {
 
     /* ============ getRoot ============ */
 
-    function test_getRoot_noLeaves() external {
-        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+    function test_getRoot_noProofElements() external {
+        vm.expectRevert(SequentialMerkleProofs.NoProofElements.selector);
         _sequentialMerkleProofs.getRoot(0, new bytes[](0), new bytes32[](0));
     }
 
-    function test_getRoot_noProofElements() external {
-        vm.expectRevert(SequentialMerkleProofs.NoProofElements.selector);
-        _sequentialMerkleProofs.getRoot(0, new bytes[](1), new bytes32[](0));
+    function test_getRoot_noLeafs_nonZeroStartingIndex() external {
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        (_sequentialMerkleProofs.getRoot(1, new bytes[](0), new bytes32[](1)));
+    }
+
+    function test_getRoot_noLeafs_nonZeroLeafCount() external {
+        bytes32[] memory proofElements_ = new bytes32[](1);
+        proofElements_[0] = bytes32(uint256(1));
+
+        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
+        _sequentialMerkleProofs.getRoot(0, new bytes[](0), proofElements_);
     }
 
     function test_getRoot_invalidProof() external {
@@ -641,6 +666,10 @@ contract SequentialMerkleProofsTests is Test {
 
         vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
         _sequentialMerkleProofs.getRoot(0, leaves_, proofElements_);
+    }
+
+    function test_getRoot_noLeaves() external {
+        assertEq(_sequentialMerkleProofs.getRoot(0, new bytes[](0), new bytes32[](1)), bytes32(0));
     }
 
     function test_getRoot_balanced_sample1() external view {
@@ -857,17 +886,13 @@ contract SequentialMerkleProofsTests is Test {
 
     /* ============ getBalancedLeafCount ============ */
 
-    function test_getBalancedLeafCount_noLeaves() external {
-        vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
-        _sequentialMerkleProofs.__getBalancedLeafCount(0);
-    }
-
     function test_getBalancedLeafCount_invalidBitCount32Input() external {
         vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
         _sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint32).max) + 1);
     }
 
     function test_getBalancedLeafCount() external view {
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(0), 0);
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(1), 2);
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(2), 2);
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(3), 4);

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -117,14 +117,14 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new bytes32[](0));
     }
 
-    function test_verify_invalidRoundUpToPowerOf2Input() external {
+    function test_verify_invalidBitCount64Input() external {
         bytes[] memory leaves_ = new bytes[](1);
         leaves_[0] = bytes(hex"00");
 
         bytes32[] memory proofElements_ = new bytes32[](1);
         proofElements_[0] = bytes32(uint256(type(uint64).max) + 1);
 
-        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
         _sequentialMerkleProofs.verify(0, 0, leaves_, proofElements_);
     }
 
@@ -620,14 +620,14 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.getRoot(0, new bytes[](1), new bytes32[](1));
     }
 
-    function test_getRoot_invalidRoundUpToPowerOf2Input() external {
+    function test_getRoot_invalidBitCount64Input() external {
         bytes[] memory leaves_ = new bytes[](1);
         leaves_[0] = bytes(hex"00");
 
         bytes32[] memory proofElements_ = new bytes32[](1);
         proofElements_[0] = bytes32(uint256(type(uint64).max) + 1);
 
-        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
         _sequentialMerkleProofs.getRoot(0, leaves_, proofElements_);
     }
 
@@ -814,8 +814,8 @@ contract SequentialMerkleProofsTests is Test {
         }
     }
 
-    function test_roundUpToPowerOf2_invalidRoundUpToPowerOf2Input() external {
-        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+    function test_roundUpToPowerOf2_invalidBitCount64Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
         _sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint64).max) + 1);
     }
 
@@ -834,8 +834,8 @@ contract SequentialMerkleProofsTests is Test {
 
         for (uint256 i_ = 4; i_ < 64; ++i_) {
             assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(1 << i_), 1 << i_); // Exact power of 2
-            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << i_) - 1), 1 << i_); // One less than
-            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << (i_ - 1)) + 1), 1 << i_); // One more than prev
+            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << i_) - 1), 1 << i_); // 1 less than
+            assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << (i_ - 1)) + 1), 1 << i_); // 1 more than prev
         }
     }
 
@@ -844,8 +844,8 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.__getBalancedLeafCount(0);
     }
 
-    function test_getBalancedLeafCount_invalidRoundUpToPowerOf2Input() external {
-        vm.expectRevert(SequentialMerkleProofs.InvalidRoundUpToPowerOf2Input.selector);
+    function test_getBalancedLeafCount_invalidBitCount64Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
         _sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint64).max) + 1);
     }
 
@@ -863,8 +863,8 @@ contract SequentialMerkleProofsTests is Test {
 
         for (uint256 i_ = 4; i_ < 64; ++i_) {
             assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(1 << i_), 1 << i_); // Exact power of 2
-            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << i_) - 1), 1 << i_); // One less than
-            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << (i_ - 1)) + 1), 1 << i_); // One more than prev
+            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << i_) - 1), 1 << i_); // 1 less than
+            assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << (i_ - 1)) + 1), 1 << i_); // 1 more than prev
         }
     }
 

--- a/test/unit/SequentialMerkleProofs.t.sol
+++ b/test/unit/SequentialMerkleProofs.t.sol
@@ -14,6 +14,8 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs = new SequentialMerkleProofsHarness();
     }
 
+    /* ============ hashLeaf ============ */
+
     function test_hashLeaf() external view {
         assertEq(
             _sequentialMerkleProofs.__hashLeaf("Hello"),
@@ -35,6 +37,8 @@ contract SequentialMerkleProofsTests is Test {
             0xa5fe16054246ec55b4c4f376e432cce9f5d7e9c6859bf2801c1d05e0a187341c
         );
     }
+
+    /* ============ hashNodePair ============ */
 
     function test_hashNodePair() external view {
         assertEq(
@@ -61,6 +65,8 @@ contract SequentialMerkleProofsTests is Test {
             0xcf86af75a8a3ad149001943d69c6f6baf87e648e765e365f9aea84c06a306fea
         );
     }
+
+    /* ============ hashPairlessNode ============ */
 
     function test_hashPairlessNode() external view {
         assertEq(
@@ -92,6 +98,8 @@ contract SequentialMerkleProofsTests is Test {
         );
     }
 
+    /* ============ hashRoot ============ */
+
     function test_hashRoot() external view {
         assertEq(
             _sequentialMerkleProofs.__hashRoot(1, 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f),
@@ -112,19 +120,21 @@ contract SequentialMerkleProofsTests is Test {
         );
     }
 
+    /* ============ verify ============ */
+
     function test_verify_noLeafs() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
         _sequentialMerkleProofs.verify(0, 0, new bytes[](0), new bytes32[](0));
     }
 
-    function test_verify_invalidBitCount64Input() external {
+    function test_verify_invalidBitCount32Input() external {
         bytes[] memory leaves_ = new bytes[](1);
         leaves_[0] = bytes(hex"00");
 
         bytes32[] memory proofElements_ = new bytes32[](1);
-        proofElements_[0] = bytes32(uint256(type(uint64).max) + 1);
+        proofElements_[0] = bytes32(uint256(type(uint32).max) + 1);
 
-        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
         _sequentialMerkleProofs.verify(0, 0, leaves_, proofElements_);
     }
 
@@ -605,6 +615,8 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
 
+    /* ============ getRoot ============ */
+
     function test_getRoot_noLeaves() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
         _sequentialMerkleProofs.getRoot(0, new bytes[](0), new bytes32[](0));
@@ -620,14 +632,14 @@ contract SequentialMerkleProofsTests is Test {
         _sequentialMerkleProofs.getRoot(0, new bytes[](1), new bytes32[](1));
     }
 
-    function test_getRoot_invalidBitCount64Input() external {
+    function test_getRoot_invalidBitCount32Input() external {
         bytes[] memory leaves_ = new bytes[](1);
         leaves_[0] = bytes(hex"00");
 
         bytes32[] memory proofElements_ = new bytes32[](1);
-        proofElements_[0] = bytes32(uint256(type(uint64).max) + 1);
+        proofElements_[0] = bytes32(uint256(type(uint32).max) + 1);
 
-        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
         _sequentialMerkleProofs.getRoot(0, leaves_, proofElements_);
     }
 
@@ -799,24 +811,28 @@ contract SequentialMerkleProofsTests is Test {
         assertEq(_sequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_), expectedRoot_);
     }
 
-    function test_bitCount64_invalidBitCount64Input() external {
-        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
-        _sequentialMerkleProofs.__bitCount64(uint256(type(uint64).max) + 1);
+    /* ============ bitCount32 ============ */
+
+    function test_bitCount32_invalidBitCount32Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
+        _sequentialMerkleProofs.__bitCount32(uint256(type(uint32).max) + 1);
     }
 
-    function test_bitCount64() external view {
-        assertEq(_sequentialMerkleProofs.__bitCount64(1 >> 1), 0);
-        assertEq(_sequentialMerkleProofs.__bitCount64(uint256(type(uint64).max)), 64);
+    function test_bitCount32() external view {
+        assertEq(_sequentialMerkleProofs.__bitCount32(1 >> 1), 0);
+        assertEq(_sequentialMerkleProofs.__bitCount32(uint256(type(uint32).max)), 32);
 
-        for (uint256 i_ = 0; i_ < 64; ++i_) {
-            assertEq(_sequentialMerkleProofs.__bitCount64(1 << i_), 1); // One bit set
-            assertEq(_sequentialMerkleProofs.__bitCount64((1 << i_) - 1), i_); // i_ bits set
+        for (uint256 i_ = 0; i_ < 32; ++i_) {
+            assertEq(_sequentialMerkleProofs.__bitCount32(1 << i_), 1); // One bit set
+            assertEq(_sequentialMerkleProofs.__bitCount32((1 << i_) - 1), i_); // i_ bits set
         }
     }
 
-    function test_roundUpToPowerOf2_invalidBitCount64Input() external {
-        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
-        _sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint64).max) + 1);
+    /* ============ roundUpToPowerOf2 ============ */
+
+    function test_roundUpToPowerOf2_invalidBitCount32Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
+        _sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint32).max) + 1);
     }
 
     function test_roundUpToPowerOf2() external view {
@@ -830,23 +846,25 @@ contract SequentialMerkleProofsTests is Test {
         assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(7), 8);
         assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(8), 8);
 
-        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint64).max)), 1 << 64);
+        assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(uint256(type(uint32).max)), 1 << 32);
 
-        for (uint256 i_ = 4; i_ < 64; ++i_) {
+        for (uint256 i_ = 4; i_ < 32; ++i_) {
             assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2(1 << i_), 1 << i_); // Exact power of 2
             assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << i_) - 1), 1 << i_); // 1 less than
             assertEq(_sequentialMerkleProofs.__roundUpToPowerOf2((1 << (i_ - 1)) + 1), 1 << i_); // 1 more than prev
         }
     }
 
+    /* ============ getBalancedLeafCount ============ */
+
     function test_getBalancedLeafCount_noLeaves() external {
         vm.expectRevert(SequentialMerkleProofs.NoLeaves.selector);
         _sequentialMerkleProofs.__getBalancedLeafCount(0);
     }
 
-    function test_getBalancedLeafCount_invalidBitCount64Input() external {
-        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount64Input.selector);
-        _sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint64).max) + 1);
+    function test_getBalancedLeafCount_invalidBitCount32Input() external {
+        vm.expectRevert(SequentialMerkleProofs.InvalidBitCount32Input.selector);
+        _sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint32).max) + 1);
     }
 
     function test_getBalancedLeafCount() external view {
@@ -859,14 +877,16 @@ contract SequentialMerkleProofsTests is Test {
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(7), 8);
         assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(8), 8);
 
-        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint64).max)), 1 << 64);
+        assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(uint256(type(uint32).max)), 1 << 32);
 
-        for (uint256 i_ = 4; i_ < 64; ++i_) {
+        for (uint256 i_ = 4; i_ < 32; ++i_) {
             assertEq(_sequentialMerkleProofs.__getBalancedLeafCount(1 << i_), 1 << i_); // Exact power of 2
             assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << i_) - 1), 1 << i_); // 1 less than
             assertEq(_sequentialMerkleProofs.__getBalancedLeafCount((1 << (i_ - 1)) + 1), 1 << i_); // 1 more than prev
         }
     }
+
+    /* ============ getReversedLeafNodesFromLeaves ============ */
 
     function test_getReversedLeafNodesFromLeaves() external view {
         bytes[] memory leaves_ = new bytes[](4);

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -125,30 +125,22 @@ contract NodeRegistryHarness is NodeRegistry {
         _getNodeRegistryStorage().admin = admin_;
     }
 
-    function __setNodeManager(address nodeManager_) external {
-        _getNodeRegistryStorage().nodeManager = nodeManager_;
-    }
-
-    function __setNodeOperatorCommissionPercent(uint256 nodeOperatorCommissionPercent_) external {
-        _getNodeRegistryStorage().nodeOperatorCommissionPercent = uint16(nodeOperatorCommissionPercent_);
-    }
-
     function __addNodeToCanonicalNetwork(uint256 nodeId_) external {
-        _getNodeRegistryStorage().nodes[nodeId_].isCanonical = true;
+        _getNodeRegistryStorage().nodes[uint32(nodeId_)].isCanonical = true;
     }
 
     function __removeNodeFromCanonicalNetwork(uint256 nodeId_) external {
-        delete _getNodeRegistryStorage().nodes[nodeId_].isCanonical;
+        delete _getNodeRegistryStorage().nodes[uint32(nodeId_)].isCanonical;
     }
 
     function __setNode(
         uint256 nodeId_,
-        bytes calldata signingKeyPub_,
-        string calldata httpAddress_,
+        address signer_,
         bool inCanonical_,
-        uint256 minMonthlyFee_
+        bytes calldata signingKeyPub_,
+        string calldata httpAddress_
     ) external {
-        _getNodeRegistryStorage().nodes[nodeId_] = Node(signingKeyPub_, httpAddress_, inCanonical_, minMonthlyFee_);
+        _getNodeRegistryStorage().nodes[uint32(nodeId_)] = Node(signer_, inCanonical_, signingKeyPub_, httpAddress_);
     }
 
     function __setApproval(address to_, uint256 tokenId_, address authorizer_) external {
@@ -160,7 +152,7 @@ contract NodeRegistryHarness is NodeRegistry {
     }
 
     function __getNode(uint256 nodeId_) external view returns (Node memory node_) {
-        return _getNodeRegistryStorage().nodes[nodeId_];
+        return _getNodeRegistryStorage().nodes[uint32(nodeId_)];
     }
 
     function __getOwner(uint256 nodeId_) external view returns (address owner_) {
@@ -176,7 +168,7 @@ contract NodeRegistryHarness is NodeRegistry {
     }
 
     function __getIsCanonicalNode(uint256 nodeId_) external view returns (bool isCanonicalNode_) {
-        return _getNodeRegistryStorage().nodes[nodeId_].isCanonical;
+        return _getNodeRegistryStorage().nodes[uint32(nodeId_)].isCanonical;
     }
 }
 

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -376,8 +376,8 @@ contract SequentialMerkleProofsHarness {
         return SequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_);
     }
 
-    function __bitCount64(uint256 n_) external pure returns (uint256 bitCount_) {
-        return SequentialMerkleProofs._bitCount64(n_);
+    function __bitCount32(uint256 n_) external pure returns (uint256 bitCount_) {
+        return SequentialMerkleProofs._bitCount32(n_);
     }
 
     function __roundUpToPowerOf2(uint256 n_) external pure returns (uint256 powerOf2_) {

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import { EnumerableSet } from "../../lib/oz/contracts/utils/structs/EnumerableSet.sol";
 
 import { ParameterKeys } from "../../src/libraries/ParameterKeys.sol";
+import { SequentialMerkleProofs } from "../../src/libraries/SequentialMerkleProofs.sol";
 
 import { AppChainGateway } from "../../src/app-chain/AppChainGateway.sol";
 import { AppChainParameterRegistry } from "../../src/app-chain/AppChainParameterRegistry.sol";
@@ -354,5 +355,58 @@ contract ParameterKeysHarness {
 
     function uint256ToKeyComponent(uint256 value_) external pure returns (bytes memory keyComponent_) {
         return ParameterKeys.uint256ToKeyComponent(value_);
+    }
+}
+
+contract SequentialMerkleProofsHarness {
+    function verify(
+        uint256 root_,
+        uint256 startingIndex_,
+        bytes[] calldata leaves_,
+        uint256[] calldata proofElements_
+    ) external pure {
+        SequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
+    }
+
+    function getRoot(
+        uint256 startingIndex_,
+        bytes[] calldata leaves_,
+        uint256[] calldata proofElements_
+    ) external pure returns (uint256 root_) {
+        return SequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_);
+    }
+
+    function __bitCount64(uint256 n_) external pure returns (uint256 bitCount_) {
+        return SequentialMerkleProofs._bitCount64(n_);
+    }
+
+    function __roundUpToPowerOf2(uint256 n_) external pure returns (uint256 powerOf2_) {
+        return SequentialMerkleProofs._roundUpToPowerOf2(n_);
+    }
+
+    function __getBalancedLeafCount(uint256 leafCount_) external pure returns (uint256 balancedLeafCount_) {
+        return SequentialMerkleProofs._getBalancedLeafCount(leafCount_);
+    }
+
+    function __hashLeaf(bytes calldata leaf_) external pure returns (uint256 hash_) {
+        return SequentialMerkleProofs._hashLeaf(leaf_);
+    }
+
+    function __hashNodePair(uint256 leftNode_, uint256 rightNode_) external pure returns (uint256 hash_) {
+        return SequentialMerkleProofs._hashNodePair(leftNode_, rightNode_);
+    }
+
+    function __hashPairlessNode(uint256 node_) external pure returns (uint256 hash_) {
+        return SequentialMerkleProofs._hashPairlessNode(node_);
+    }
+
+    function __hashRoot(uint256 leafCount_, uint256 root_) external pure returns (uint256 hash_) {
+        return SequentialMerkleProofs._hashRoot(leafCount_, root_);
+    }
+
+    function __getReversedLeafNodesFromLeaves(
+        bytes[] calldata leaves_
+    ) external pure returns (uint256[] memory reversedLeaves_) {
+        return SequentialMerkleProofs._getReversedLeafNodesFromLeaves(leaves_);
     }
 }

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -376,6 +376,10 @@ contract SequentialMerkleProofsHarness {
         return SequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_);
     }
 
+    function getLeafCount(bytes32[] calldata proofElements_) external pure returns (uint256 leafCount_) {
+        return SequentialMerkleProofs.getLeafCount(proofElements_);
+    }
+
     function __bitCount32(uint256 n_) external pure returns (uint256 bitCount_) {
         return SequentialMerkleProofs._bitCount32(n_);
     }

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -360,10 +360,10 @@ contract ParameterKeysHarness {
 
 contract SequentialMerkleProofsHarness {
     function verify(
-        uint256 root_,
+        bytes32 root_,
         uint256 startingIndex_,
         bytes[] calldata leaves_,
-        uint256[] calldata proofElements_
+        bytes32[] calldata proofElements_
     ) external pure {
         SequentialMerkleProofs.verify(root_, startingIndex_, leaves_, proofElements_);
     }
@@ -371,8 +371,8 @@ contract SequentialMerkleProofsHarness {
     function getRoot(
         uint256 startingIndex_,
         bytes[] calldata leaves_,
-        uint256[] calldata proofElements_
-    ) external pure returns (uint256 root_) {
+        bytes32[] calldata proofElements_
+    ) external pure returns (bytes32 root_) {
         return SequentialMerkleProofs.getRoot(startingIndex_, leaves_, proofElements_);
     }
 
@@ -388,25 +388,25 @@ contract SequentialMerkleProofsHarness {
         return SequentialMerkleProofs._getBalancedLeafCount(leafCount_);
     }
 
-    function __hashLeaf(bytes calldata leaf_) external pure returns (uint256 hash_) {
+    function __hashLeaf(bytes calldata leaf_) external pure returns (bytes32 hash_) {
         return SequentialMerkleProofs._hashLeaf(leaf_);
     }
 
-    function __hashNodePair(uint256 leftNode_, uint256 rightNode_) external pure returns (uint256 hash_) {
+    function __hashNodePair(bytes32 leftNode_, bytes32 rightNode_) external pure returns (bytes32 hash_) {
         return SequentialMerkleProofs._hashNodePair(leftNode_, rightNode_);
     }
 
-    function __hashPairlessNode(uint256 node_) external pure returns (uint256 hash_) {
+    function __hashPairlessNode(bytes32 node_) external pure returns (bytes32 hash_) {
         return SequentialMerkleProofs._hashPairlessNode(node_);
     }
 
-    function __hashRoot(uint256 leafCount_, uint256 root_) external pure returns (uint256 hash_) {
+    function __hashRoot(uint256 leafCount_, bytes32 root_) external pure returns (bytes32 hash_) {
         return SequentialMerkleProofs._hashRoot(leafCount_, root_);
     }
 
     function __getReversedLeafNodesFromLeaves(
         bytes[] calldata leaves_
-    ) external pure returns (uint256[] memory reversedLeaves_) {
+    ) external pure returns (bytes32[] memory reversedLeaves_) {
         return SequentialMerkleProofs._getReversedLeafNodesFromLeaves(leaves_);
     }
 }

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -137,10 +137,10 @@ contract NodeRegistryHarness is NodeRegistry {
         uint256 nodeId_,
         address signer_,
         bool inCanonical_,
-        bytes calldata signingKeyPub_,
+        bytes calldata signingPublicKey_,
         string calldata httpAddress_
     ) external {
-        _getNodeRegistryStorage().nodes[uint32(nodeId_)] = Node(signer_, inCanonical_, signingKeyPub_, httpAddress_);
+        _getNodeRegistryStorage().nodes[uint32(nodeId_)] = Node(signer_, inCanonical_, signingPublicKey_, httpAddress_);
     }
 
     function __setApproval(address to_, uint256 tokenId_, address authorizer_) external {


### PR DESCRIPTION
- drop `minMonthlyFee`
- added `signer` address derived from `signingPublicKey`
- `nodeId` defined explicitly as `uint32`
- node manager removed
- added a `MaxNodesReached` check
- `addNode` now returns the derived address of the signer as well
- `getSigner` getter added
- "operators" renamed to "owners" to keep in like with the NFT owner nomenclature
- `setHttpAddress` now callable by the node owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ability to retrieve a node's signer address directly.

- **Refactor**
  - Simplified node management by removing the node manager role and commission-related logic.
  - Node ownership and actions are now handled directly by node owners.
  - Node identifiers changed from 256-bit to 32-bit for improved efficiency.
  - Updated token name and symbol to "XMTP Nodes" and "nXMTP".

- **Bug Fixes**
  - Improved error handling for node ownership and maximum node limits.

- **Tests**
  - Updated and simplified test suites to reflect removal of node manager and commission logic.
  - Added new tests for maximum node limits and signer retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->