### PR TITLE
feat: `DistributionManager`

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -165,7 +165,7 @@ jobs:
       - run: chmod +x /usr/local/bin/forge
 
       - name: Run Forge tests with gas report
-        run: forge test --gas-report --gas-limit 2000000000 > gasreport.ansi
+        run: forge test -fuzz-seed 10101 --gas-report --gas-limit 2000000000 > gasreport.ansi
         env:
           # make fuzzing semi-deterministic to avoid noisy gas cost estimation
           # due to non-deterministic fuzzing (but still use pseudo-random fuzzing seeds)

--- a/.solhint.json
+++ b/.solhint.json
@@ -37,7 +37,6 @@
             "warn",
             6
         ],
-        "func-order": "warn",
         "func-param-name-mixedcase": "error",
         "func-visibility": [
             "error",

--- a/src/settlement-chain/DistributionManager.sol
+++ b/src/settlement-chain/DistributionManager.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { SafeTransferLib } from "../../lib/solady/src/utils/SafeTransferLib.sol";
+
+import { Initializable } from "../../lib/oz-upgradeable/contracts/proxy/utils/Initializable.sol";
+
+import { IMigratable } from "../abstract/interfaces/IMigratable.sol";
+import { IDistributionManager } from "./interfaces/IDistributionManager.sol";
+import {
+    IParameterRegistryLike,
+    INodeRegistryLike,
+    IPayerReportManagerLike,
+    IERC20Like
+} from "./interfaces/External.sol";
+
+import { Migratable } from "../abstract/Migratable.sol";
+
+/**
+ * @title  Implementation of the Distribution Manager.
+ * @notice This contract handles functionality for distributing fees.
+ */
+contract DistributionManager is IDistributionManager, Initializable, Migratable {
+    /* ============ Constants/Immutables ============ */
+
+    /// @inheritdoc IDistributionManager
+    address public immutable parameterRegistry;
+
+    /// @inheritdoc IDistributionManager
+    address public immutable nodeRegistry;
+
+    /// @inheritdoc IDistributionManager
+    address public immutable payerReportManager;
+
+    /// @inheritdoc IDistributionManager
+    address public immutable token;
+
+    /* ============ UUPS Storage ============ */
+
+    /**
+     * @custom:storage-location erc7201:xmtp.storage.DistributionManager
+     * @notice The UUPS storage for the distribution manager.
+     */
+    struct DistributionManagerStorage {
+        mapping(uint32 nodeId => mapping(uint32 originatorNodeId => mapping(uint256 payerReportIndex => bool hasClaimed))) hasClaimed;
+        mapping(uint32 nodeId => uint96 owedFees) owedFees;
+        uint96 totalOwedFees;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("xmtp.storage.DistributionManager")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant _DISTRIBUTION_MANAGER_STORAGE_LOCATION =
+        0xecaf10aa029fa936ea42e5f15011e2f38c8598ffef434459a36a3d154fde2a00;
+
+    function _getDistributionManagerStorage() internal pure returns (DistributionManagerStorage storage $) {
+        // slither-disable-next-line assembly
+        assembly {
+            $.slot := _DISTRIBUTION_MANAGER_STORAGE_LOCATION
+        }
+    }
+
+    /* ============ Constructor ============ */
+
+    /**
+     * @notice Constructor for the implementation contract, such that the implementation cannot be initialized.
+     * @param  parameterRegistry_  The address of the parameter registry.
+     * @param  nodeRegistry_       The address of the node registry.
+     * @param  payerReportManager_ The address of the payer report manager.
+     * @param  token_              The address of the token.
+     * @dev    The parameter registry, node registry, and payer report manager must not be the zero address.
+     * @dev    The parameter registry, node registry, and payer report manager are immutable so that they are inlined
+     *         in the contract code, and have minimal gas cost.
+     */
+    constructor(address parameterRegistry_, address nodeRegistry_, address payerReportManager_, address token_) {
+        if (_isZero(parameterRegistry = parameterRegistry_)) revert ZeroParameterRegistry();
+        if (_isZero(nodeRegistry = nodeRegistry_)) revert ZeroNodeRegistry();
+        if (_isZero(payerReportManager = payerReportManager_)) revert ZeroPayerReportManager();
+        if (_isZero(token = token_)) revert ZeroToken();
+
+        _disableInitializers();
+    }
+
+    /* ============ Initialization ============ */
+
+    /// @inheritdoc IDistributionManager
+    function initialize() public initializer {}
+
+    /* ============ Interactive Functions ============ */
+
+    /// @inheritdoc IDistributionManager
+    function claim(
+        uint32 nodeId_,
+        uint32[] calldata originatorNodeIds_,
+        uint256[] calldata payerReportIndices_
+    ) external returns (uint96 claimed_) {
+        _revertIfNotNodeOwner(nodeId_);
+
+        IPayerReportManagerLike.PayerReport[] memory payerReports_ = IPayerReportManagerLike(payerReportManager)
+            .getPayerReports(originatorNodeIds_, payerReportIndices_);
+
+        DistributionManagerStorage storage $ = _getDistributionManagerStorage();
+
+        for (uint256 index_; index_ < payerReports_.length; ++index_) {
+            // This makes the assumption that the returned array of payer reports from `getPayerReports` is of the same
+            // length, and in the same order, as the arrays of originator node IDs and payer report indices.
+            uint32 originatorNodeId_ = originatorNodeIds_[index_];
+            uint256 payerReportIndex_ = payerReportIndices_[index_];
+
+            if ($.hasClaimed[nodeId_][originatorNodeId_][payerReportIndex_]) {
+                revert AlreadyClaimed(originatorNodeId_, payerReportIndex_);
+            }
+
+            IPayerReportManagerLike.PayerReport memory payerReport_ = payerReports_[index_];
+
+            if (!payerReport_.isSettled) revert PayerReportNotSettled(originatorNodeId_, payerReportIndex_);
+
+            uint32[] memory nodeIds_ = payerReport_.nodeIds;
+
+            if (!_isInNodeIds(nodeId_, nodeIds_)) {
+                revert NotInPayerReport(originatorNodeId_, payerReportIndex_);
+            }
+
+            $.hasClaimed[nodeId_][originatorNodeId_][payerReportIndex_] = true;
+
+            // `nodeIds_.length` must be at least 1 for `_isInNodeIds` to have returned `true`.
+            uint96 feePortion_ = payerReport_.feesSettled / uint96(nodeIds_.length);
+
+            unchecked {
+                claimed_ += feePortion_;
+            }
+
+            emit Claim(nodeId_, originatorNodeId_, payerReportIndex_, feePortion_);
+        }
+
+        unchecked {
+            $.owedFees[nodeId_] += claimed_;
+            $.totalOwedFees += claimed_;
+        }
+    }
+
+    /// @inheritdoc IDistributionManager
+    function withdraw(uint32 nodeId_, address destination_) external returns (uint96 withdrawn_) {
+        if (_isZero(destination_)) revert ZeroDestination();
+
+        _revertIfNotNodeOwner(nodeId_);
+
+        DistributionManagerStorage storage $ = _getDistributionManagerStorage();
+
+        uint96 owedFees_ = $.owedFees[nodeId_];
+
+        if (owedFees_ == 0) revert NoFeesOwed();
+
+        uint96 availableBalance_ = uint96(IERC20Like(token).balanceOf(address(this)));
+
+        // slither-disable-next-line incorrect-equality
+        if (availableBalance_ == 0) revert ZeroAvailableBalance();
+
+        // Only withdraw up to what is available.
+        withdrawn_ = availableBalance_ >= owedFees_ ? owedFees_ : availableBalance_;
+
+        unchecked {
+            // `withdrawn_` is less than or equal to `owedFees_`, and `totalOwedFees` is the sum of all `owedFees`.
+            $.owedFees[nodeId_] = owedFees_ - withdrawn_;
+            $.totalOwedFees -= withdrawn_;
+        }
+
+        emit Withdrawal(nodeId_, withdrawn_);
+
+        SafeTransferLib.safeTransfer(token, destination_, withdrawn_);
+    }
+
+    /// @inheritdoc IMigratable
+    function migrate() external {
+        _migrate(_toAddress(_getRegistryParameter(migratorParameterKey())));
+    }
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @inheritdoc IDistributionManager
+    function migratorParameterKey() public pure returns (bytes memory key_) {
+        return "xmtp.distributionManager.migrator";
+    }
+
+    /// @inheritdoc IDistributionManager
+    function totalOwedFees() external view returns (uint96 totalOwedFees_) {
+        return _getDistributionManagerStorage().totalOwedFees;
+    }
+
+    /// @inheritdoc IDistributionManager
+    function getOwedFees(uint32 nodeId_) external view returns (uint96 owedFees_) {
+        return _getDistributionManagerStorage().owedFees[nodeId_];
+    }
+
+    /// @inheritdoc IDistributionManager
+    function getHasClaimed(
+        uint32 nodeId_,
+        uint32 originatorNodeId_,
+        uint256 payerReportIndex_
+    ) external view returns (bool hasClaimed_) {
+        return _getDistributionManagerStorage().hasClaimed[nodeId_][originatorNodeId_][payerReportIndex_];
+    }
+
+    /* ============ Internal View/Pure Functions ============ */
+
+    /// @dev Returns true if the node ID is in the list of node IDs.
+    function _isInNodeIds(uint32 nodeId_, uint32[] memory nodeIds_) internal pure returns (bool isInNodeIds_) {
+        for (uint256 index_; index_ < nodeIds_.length; ++index_) {
+            if (nodeIds_[index_] == nodeId_) return true;
+        }
+
+        return false;
+    }
+
+    function _getRegistryParameter(bytes memory key_) internal view returns (bytes32 value_) {
+        return IParameterRegistryLike(parameterRegistry).get(key_);
+    }
+
+    function _isZero(address input_) internal pure returns (bool isZero_) {
+        return input_ == address(0);
+    }
+
+    function _toAddress(bytes32 value_) internal pure returns (address address_) {
+        // slither-disable-next-line assembly
+        assembly {
+            address_ := value_
+        }
+    }
+
+    function _revertIfNotNodeOwner(uint32 nodeId_) internal view {
+        if (INodeRegistryLike(nodeRegistry).ownerOf(nodeId_) != msg.sender) revert NotNodeOwner();
+    }
+}

--- a/src/settlement-chain/PayerReportManager.sol
+++ b/src/settlement-chain/PayerReportManager.sol
@@ -222,8 +222,22 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
     }
 
     /// @inheritdoc IPayerReportManager
-    function getPayerReports(uint32 originatorNodeId_) external view returns (PayerReport[] memory payerReports_) {
-        return _getPayerReportManagerStorage().payerReportsByOriginator[originatorNodeId_];
+    function getPayerReports(
+        uint32[] calldata originatorNodeIds_,
+        uint256[] calldata payerReportIndices_
+    ) external view returns (PayerReport[] memory payerReports_) {
+        if (originatorNodeIds_.length != payerReportIndices_.length) revert ArrayLengthMismatch();
+
+        payerReports_ = new PayerReport[](originatorNodeIds_.length);
+
+        PayerReportManagerStorage storage $ = _getPayerReportManagerStorage();
+
+        for (uint256 i; i < originatorNodeIds_.length; ++i) {
+            uint32 originatorNodeId_ = originatorNodeIds_[i];
+            uint256 payerReportIndex_ = payerReportIndices_[i];
+
+            payerReports_[i] = $.payerReportsByOriginator[originatorNodeId_][payerReportIndex_];
+        }
     }
 
     /// @inheritdoc IPayerReportManager

--- a/src/settlement-chain/interfaces/External.sol
+++ b/src/settlement-chain/interfaces/External.sol
@@ -115,6 +115,8 @@ interface IPayerRegistryLike {
     }
 
     function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
+
+    function sendExcessToFeeDistributor() external returns (uint96 excess_);
 }
 
 /**

--- a/src/settlement-chain/interfaces/External.sol
+++ b/src/settlement-chain/interfaces/External.sol
@@ -100,6 +100,8 @@ interface INodeRegistryLike {
     function getIsCanonicalNode(uint32 nodeId_) external view returns (bool isCanonicalNode_);
 
     function getSigner(uint32 nodeId_) external view returns (address signer_);
+
+    function ownerOf(uint256 nodeId_) external view returns (address owner_);
 }
 
 /**
@@ -113,4 +115,25 @@ interface IPayerRegistryLike {
     }
 
     function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
+}
+
+/**
+ * @title  Subset interface for a PayerReportManager.
+ * @notice This is the minimal interface needed by contracts within this subdirectory.
+ */
+interface IPayerReportManagerLike {
+    struct PayerReport {
+        uint32 startSequenceId;
+        uint32 endSequenceId;
+        uint96 feesSettled;
+        uint32 offset;
+        bool isSettled;
+        bytes32 payersMerkleRoot;
+        uint32[] nodeIds;
+    }
+
+    function getPayerReports(
+        uint32[] calldata originatorNodeIds_,
+        uint256[] calldata payerReportIndices_
+    ) external view returns (PayerReport[] memory payerReports_);
 }

--- a/src/settlement-chain/interfaces/IDistributionManager.sol
+++ b/src/settlement-chain/interfaces/IDistributionManager.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IMigratable } from "../../abstract/interfaces/IMigratable.sol";
+
+/**
+ * @title  The interface for the Distribution Manager.
+ * @notice This interface exposes functionality for distributing fees.
+ */
+interface IDistributionManager is IMigratable {
+    /* ============ Events ============ */
+
+    /**
+     * @notice Emitted when a claim is made.
+     * @param  nodeId           The ID of the node.
+     * @param  originatorNodeId The ID of the originator node of the payer report.
+     * @param  payerReportIndex The index of the payer report.
+     * @param  amount           The amount of fees claimed.
+     */
+    event Claim(
+        uint32 indexed nodeId,
+        uint32 indexed originatorNodeId,
+        uint256 indexed payerReportIndex,
+        uint96 amount
+    );
+
+    /**
+     * @notice Emitted when a withdrawal of owed fees is made.
+     * @param  nodeId The ID of the node.
+     * @param  amount The amount of tokens withdrawn.
+     */
+    event Withdrawal(uint32 indexed nodeId, uint96 amount);
+
+    /* ============ Custom Errors ============ */
+
+    /// @notice Error thrown when the parameter registry address is being set to zero (i.e. address(0)).
+    error ZeroParameterRegistry();
+
+    /// @notice Error thrown when the node registry address is being set to zero (i.e. address(0)).
+    error ZeroNodeRegistry();
+
+    /// @notice Error thrown when the payer report manager address is being set to zero (i.e. address(0)).
+    error ZeroPayerReportManager();
+
+    /// @notice Error thrown when the token address is being set to zero (i.e. address(0)).
+    error ZeroToken();
+
+    /// @notice Error thrown when the caller is not the owner of the specified node.
+    error NotNodeOwner();
+
+    /// @notice Error thrown when a payer report has already been claimed.
+    error AlreadyClaimed(uint32 originatorNodeId, uint256 payerReportIndex);
+
+    /// @notice Error thrown when the payer report is not settled.
+    error PayerReportNotSettled(uint32 originatorNodeId, uint256 payerReportIndex);
+
+    /// @notice Error thrown when the node ID is not in a payer report.
+    error NotInPayerReport(uint32 originatorNodeId, uint256 payerReportIndex);
+
+    /// @notice Error thrown when the destination address is zero (i.e. address(0)).
+    error ZeroDestination();
+
+    /// @notice Error thrown when the node has no fees owed.
+    error NoFeesOwed();
+
+    /// @notice Error thrown when the contract's available balance is zero.
+    error ZeroAvailableBalance();
+
+    /**
+     * @notice Thrown when the `ERC20.transfer` call fails.
+     * @dev    This is an identical redefinition of `SafeTransferLib.TransferFailed`.
+     */
+    error TransferFailed();
+
+    /* ============ Initialization ============ */
+
+    /**
+     * @notice Initializes the contract.
+     */
+    function initialize() external;
+
+    /* ============ Interactive Functions ============ */
+
+    /**
+     * @notice Claims fees for a node for an array of payer reports.
+     * @param  nodeId_             The ID of the node.
+     * @param  originatorNodeIds_  The IDs of the originator nodes of the payer reports.
+     * @param  payerReportIndices_ The payer report indices for each of the respective originator node IDs.
+     * @return claimed_            The amount of fees claimed.
+     * @dev    The node IDs in `originatorNodeIds_` do not need to be unique.
+     */
+    function claim(
+        uint32 nodeId_,
+        uint32[] calldata originatorNodeIds_,
+        uint256[] calldata payerReportIndices_
+    ) external returns (uint96 claimed_);
+
+    /**
+     * @notice Withdraws fees for a node.
+     * @param  nodeId_      The ID of the node.
+     * @param  destination_ The address to withdraw the fees to.
+     * @return withdrawn_   The amount of fees withdrawn.
+     */
+    function withdraw(uint32 nodeId_, address destination_) external returns (uint96 withdrawn_);
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @notice The parameter registry key used to fetch the migrator.
+    function migratorParameterKey() external pure returns (bytes memory key_);
+
+    /// @notice The address of the parameter registry.
+    function parameterRegistry() external view returns (address parameterRegistry_);
+
+    /// @notice The address of the node registry.
+    function nodeRegistry() external view returns (address nodeRegistry_);
+
+    /// @notice The address of the payer report manager.
+    function payerReportManager() external view returns (address payerReportManager_);
+
+    /// @notice The address of the token.
+    function token() external view returns (address token_);
+
+    /// @notice The total amount of fees owed.
+    function totalOwedFees() external view returns (uint96 totalOwedFees_);
+
+    /**
+     * @notice Returns the amount of claimed fees owed to a node.
+     * @param  nodeId_   The ID of the node.
+     * @return owedFees_ The amount of fees owed.
+     */
+    function getOwedFees(uint32 nodeId_) external view returns (uint96 owedFees_);
+
+    /**
+     * @notice Returns whether a node has claimed a payer report.
+     * @param  nodeId_           The ID of the node.
+     * @param  originatorNodeId_ The ID of the originator node of the payer report.
+     * @param  payerReportIndex_ The index of the payer report.
+     * @return hasClaimed_       Whether the node has claimed fees associated with a settled payer report.
+     */
+    function getHasClaimed(
+        uint32 nodeId_,
+        uint32 originatorNodeId_,
+        uint256 payerReportIndex_
+    ) external view returns (bool hasClaimed_);
+}

--- a/src/settlement-chain/interfaces/IDistributionManager.sol
+++ b/src/settlement-chain/interfaces/IDistributionManager.sol
@@ -33,37 +33,43 @@ interface IDistributionManager is IMigratable {
 
     /* ============ Custom Errors ============ */
 
-    /// @notice Error thrown when the parameter registry address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the parameter registry address is being set to zero (i.e. address(0)).
     error ZeroParameterRegistry();
 
-    /// @notice Error thrown when the node registry address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the node registry address is being set to zero (i.e. address(0)).
     error ZeroNodeRegistry();
 
-    /// @notice Error thrown when the payer report manager address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the payer report manager address is being set to zero (i.e. address(0)).
     error ZeroPayerReportManager();
 
-    /// @notice Error thrown when the token address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the payer registry address is being set to zero (i.e. address(0)).
+    error ZeroPayerRegistry();
+
+    /// @notice Thrown when the token address is being set to zero (i.e. address(0)).
     error ZeroToken();
 
-    /// @notice Error thrown when the caller is not the owner of the specified node.
+    /// @notice Thrown when the caller is not the owner of the specified node.
     error NotNodeOwner();
 
-    /// @notice Error thrown when a payer report has already been claimed.
+    /// @notice Thrown when the length of two input arrays do not match when they should.
+    error ArrayLengthMismatch();
+
+    /// @notice Thrown when a payer report has already been claimed.
     error AlreadyClaimed(uint32 originatorNodeId, uint256 payerReportIndex);
 
-    /// @notice Error thrown when the payer report is not settled.
+    /// @notice Thrown when the payer report is not settled.
     error PayerReportNotSettled(uint32 originatorNodeId, uint256 payerReportIndex);
 
-    /// @notice Error thrown when the node ID is not in a payer report.
+    /// @notice Thrown when the node ID is not in a payer report.
     error NotInPayerReport(uint32 originatorNodeId, uint256 payerReportIndex);
 
-    /// @notice Error thrown when the destination address is zero (i.e. address(0)).
+    /// @notice Thrown when the destination address is zero (i.e. address(0)).
     error ZeroDestination();
 
-    /// @notice Error thrown when the node has no fees owed.
+    /// @notice Thrown when the node has no fees owed.
     error NoFeesOwed();
 
-    /// @notice Error thrown when the contract's available balance is zero.
+    /// @notice Thrown when the contract's available balance is zero.
     error ZeroAvailableBalance();
 
     /**
@@ -116,6 +122,9 @@ interface IDistributionManager is IMigratable {
 
     /// @notice The address of the payer report manager.
     function payerReportManager() external view returns (address payerReportManager_);
+
+    /// @notice The address of the payer registry.
+    function payerRegistry() external view returns (address payerRegistry_);
 
     /// @notice The address of the token.
     function token() external view returns (address token_);

--- a/src/settlement-chain/interfaces/IPayerReportManager.sol
+++ b/src/settlement-chain/interfaces/IPayerReportManager.sol
@@ -111,6 +111,9 @@ interface IPayerReportManager is IMigratable, IERC5267 {
     /// @notice Error thrown when failing to settle usage via the payer registry.
     error SettleUsageFailed(bytes returnData_);
 
+    /// @notice Thrown when the array length mismatch (e.g. when setting multiple parameters).
+    error ArrayLengthMismatch();
+
     /* ============ Initialization ============ */
 
     /**
@@ -168,11 +171,16 @@ interface IPayerReportManager is IMigratable, IERC5267 {
     function payerRegistry() external view returns (address payerRegistry_);
 
     /**
-     * @notice Returns the payer reports for an originator node.
-     * @param  originatorNodeId_ The originator node ID.
-     * @return payerReports_     The array of payer reports.
+     * @notice Returns an array of specific payer reports.
+     * @param  originatorNodeIds_  An array of originator node IDs.
+     * @param  payerReportIndices_ An array of payer report indices for each of the respective originator node IDs.
+     * @return payerReports_       The array of payer reports.
+     * @dev    The node IDs in `originatorNodeIds_` do not need to be unique.
      */
-    function getPayerReports(uint32 originatorNodeId_) external view returns (PayerReport[] memory payerReports_);
+    function getPayerReports(
+        uint32[] calldata originatorNodeIds_,
+        uint256[] calldata payerReportIndices_
+    ) external view returns (PayerReport[] memory payerReports_);
 
     /**
      * @notice Returns a payer report.

--- a/src/settlement-chain/interfaces/IPayerReportManager.sol
+++ b/src/settlement-chain/interfaces/IPayerReportManager.sol
@@ -81,37 +81,37 @@ interface IPayerReportManager is IMigratable, IERC5267 {
 
     /* ============ Custom Errors ============ */
 
-    /// @notice Error thrown when the parameter registry address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the parameter registry address is being set to zero (i.e. address(0)).
     error ZeroParameterRegistry();
 
-    /// @notice Error thrown when the node registry address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the node registry address is being set to zero (i.e. address(0)).
     error ZeroNodeRegistry();
 
-    /// @notice Error thrown when the payer registry address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the payer registry address is being set to zero (i.e. address(0)).
     error ZeroPayerRegistry();
 
-    /// @notice Error thrown when the start sequence ID is not the last end sequence ID.
+    /// @notice Thrown when the start sequence ID is not the last end sequence ID.
     error InvalidStartSequenceId(uint32 startSequenceId, uint32 lastSequenceId);
 
-    /// @notice Error thrown when the start and end sequence IDs are invalid.
+    /// @notice Thrown when the start and end sequence IDs are invalid.
     error InvalidSequenceIds();
 
-    /// @notice Error thrown when the signing node IDs are not ordered and unique.
+    /// @notice Thrown when the signing node IDs are not ordered and unique.
     error UnorderedNodeIds();
 
-    /// @notice Error thrown when the number of valid signatures is insufficient.
+    /// @notice Thrown when the number of valid signatures is insufficient.
     error InsufficientSignatures(uint8 validSignatureCount, uint8 requiredSignatureCount);
 
-    /// @notice Error thrown when the payer report index is out of bounds.
+    /// @notice Thrown when the payer report index is out of bounds.
     error PayerReportIndexOutOfBounds();
 
-    /// @notice Error thrown when the payer report has already been entirely settled.
+    /// @notice Thrown when the payer report has already been entirely settled.
     error PayerReportEntirelySettled();
 
-    /// @notice Error thrown when failing to settle usage via the payer registry.
+    /// @notice Thrown when failing to settle usage via the payer registry.
     error SettleUsageFailed(bytes returnData_);
 
-    /// @notice Thrown when the array length mismatch (e.g. when setting multiple parameters).
+    /// @notice Thrown when the length of two input arrays do not match when they should.
     error ArrayLengthMismatch();
 
     /* ============ Initialization ============ */

--- a/src/settlement-chain/interfaces/IRateRegistry.sol
+++ b/src/settlement-chain/interfaces/IRateRegistry.sol
@@ -39,7 +39,7 @@ interface IRateRegistry is IMigratable {
 
     /* ============ Custom Errors ============ */
 
-    /// @notice Error thrown when the parameter registry address is being set to zero (i.e. address(0)).
+    /// @notice Thrown when the parameter registry address is being set to zero (i.e. address(0)).
     error ZeroParameterRegistry();
 
     /// @notice Thrown when the `fromIndex` is out of range.

--- a/test/unit/DistributionManager.t.sol
+++ b/test/unit/DistributionManager.t.sol
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Test, console } from "../../lib/forge-std/src/Test.sol";
+
+import { Initializable } from "../../lib/oz-upgradeable/contracts/proxy/utils/Initializable.sol";
+
+import { IERC1967 } from "../../src/abstract/interfaces/IERC1967.sol";
+import { IMigratable } from "../../src/abstract/interfaces/IMigratable.sol";
+import { IDistributionManager } from "../../src/settlement-chain/interfaces/IDistributionManager.sol";
+import { IPayerReportManagerLike } from "../../src/settlement-chain/interfaces/External.sol";
+
+import { Proxy } from "../../src/any-chain/Proxy.sol";
+
+import { DistributionManagerHarness } from "../utils/Harnesses.sol";
+
+import {
+    MockParameterRegistry,
+    MockNodeRegistry,
+    MockPayerReportManager,
+    MockErc20,
+    MockMigrator,
+    MockFailingMigrator
+} from "../utils/Mocks.sol";
+
+import { Utils } from "../utils/Utils.sol";
+
+contract DistributionManagerTests is Test {
+    bytes internal constant _MIGRATOR_KEY = "xmtp.distributionManager.migrator";
+
+    DistributionManagerHarness internal _manager;
+
+    address internal _implementation;
+    address internal _parameterRegistry;
+    address internal _nodeRegistry;
+    address internal _payerReportManager;
+    address internal _token;
+
+    address internal _alice = makeAddr("alice");
+    address internal _bob = makeAddr("bob");
+    address internal _charlie = makeAddr("charlie");
+
+    function setUp() external {
+        _parameterRegistry = address(new MockParameterRegistry());
+        _nodeRegistry = address(new MockNodeRegistry());
+        _payerReportManager = address(new MockPayerReportManager());
+        _token = address(new MockErc20());
+
+        _implementation = address(
+            new DistributionManagerHarness(_parameterRegistry, _nodeRegistry, _payerReportManager, _token)
+        );
+
+        _manager = DistributionManagerHarness(address(new Proxy(_implementation)));
+
+        _manager.initialize();
+    }
+
+    /* ============ constructor ============ */
+
+    function test_constructor_zeroParameterRegistry() external {
+        vm.expectRevert(IDistributionManager.ZeroParameterRegistry.selector);
+        new DistributionManagerHarness(address(0), address(0), address(0), address(0));
+    }
+
+    function test_constructor_zeroNodeRegistry() external {
+        vm.expectRevert(IDistributionManager.ZeroNodeRegistry.selector);
+        new DistributionManagerHarness(_parameterRegistry, address(0), address(0), address(0));
+    }
+
+    function test_constructor_zeroPayerReportManager() external {
+        vm.expectRevert(IDistributionManager.ZeroPayerReportManager.selector);
+        new DistributionManagerHarness(_parameterRegistry, _nodeRegistry, address(0), address(0));
+    }
+
+    function test_constructor_zeroToken() external {
+        vm.expectRevert(IDistributionManager.ZeroToken.selector);
+        new DistributionManagerHarness(_parameterRegistry, _nodeRegistry, _payerReportManager, address(0));
+    }
+
+    /* ============ initial state ============ */
+
+    function test_initialState() external view {
+        assertEq(Utils.getImplementationFromSlot(address(_manager)), _implementation);
+        assertEq(_manager.implementation(), _implementation);
+        assertEq(_manager.parameterRegistry(), _parameterRegistry);
+        assertEq(_manager.nodeRegistry(), _nodeRegistry);
+        assertEq(_manager.payerReportManager(), _payerReportManager);
+        assertEq(_manager.token(), _token);
+        assertEq(_manager.migratorParameterKey(), _MIGRATOR_KEY);
+    }
+
+    /* ============ initializer ============ */
+
+    function test_initialize_reinitialization() external {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        _manager.initialize();
+    }
+
+    /* ============ claim ============ */
+
+    function test_claim_notNodeOwner() external {
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.expectRevert(IDistributionManager.NotNodeOwner.selector);
+
+        vm.prank(_bob);
+        _manager.claim(1, new uint32[](0), new uint256[](0));
+    }
+
+    function test_claim_alreadyClaimed() external {
+        uint32[] memory originatorNodeIds_ = new uint32[](2);
+        originatorNodeIds_[0] = 2;
+        originatorNodeIds_[1] = 3;
+
+        uint256[] memory payerReportIndices_ = new uint256[](2);
+        payerReportIndices_[0] = 0;
+        payerReportIndices_[1] = 0;
+
+        uint32[] memory nodeIds_ = new uint32[](3);
+        nodeIds_[0] = 1;
+        nodeIds_[1] = 2;
+        nodeIds_[2] = 3;
+
+        IPayerReportManagerLike.PayerReport[] memory payerReports_ = new IPayerReportManagerLike.PayerReport[](2);
+
+        payerReports_[0] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 0,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIds_
+        });
+
+        payerReports_[1] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 0,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIds_
+        });
+
+        _manager.__setHasClaimed(1, 3, 0, true); // Node 1 has already claimed node 3's 0th payer report.
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.mockCall(
+            _payerReportManager,
+            abi.encodeWithSignature("getPayerReports(uint32[],uint256[])", originatorNodeIds_, payerReportIndices_),
+            abi.encode(payerReports_)
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IDistributionManager.AlreadyClaimed.selector, 3, 0));
+
+        vm.prank(_alice);
+        _manager.claim(1, originatorNodeIds_, payerReportIndices_);
+    }
+
+    function test_claim_payerReportNotSettled() external {
+        uint32[] memory originatorNodeIds_ = new uint32[](2);
+        originatorNodeIds_[0] = 2;
+        originatorNodeIds_[1] = 3;
+
+        uint256[] memory payerReportIndices_ = new uint256[](2);
+        payerReportIndices_[0] = 0;
+        payerReportIndices_[1] = 0;
+
+        uint32[] memory nodeIds_ = new uint32[](3);
+        nodeIds_[0] = 1;
+        nodeIds_[1] = 2;
+        nodeIds_[2] = 3;
+
+        IPayerReportManagerLike.PayerReport[] memory payerReports_ = new IPayerReportManagerLike.PayerReport[](2);
+
+        payerReports_[0] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 0,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIds_
+        });
+
+        payerReports_[1] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 0,
+            offset: 0,
+            isSettled: false, // Second payer report is not settled.
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIds_
+        });
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.mockCall(
+            _payerReportManager,
+            abi.encodeWithSignature("getPayerReports(uint32[],uint256[])", originatorNodeIds_, payerReportIndices_),
+            abi.encode(payerReports_)
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IDistributionManager.PayerReportNotSettled.selector, 3, 0));
+
+        vm.prank(_alice);
+        _manager.claim(1, originatorNodeIds_, payerReportIndices_);
+    }
+
+    function test_claim_notInPayerReport() external {
+        uint32[] memory originatorNodeIds_ = new uint32[](2);
+        originatorNodeIds_[0] = 2;
+        originatorNodeIds_[1] = 3;
+
+        uint256[] memory payerReportIndices_ = new uint256[](2);
+        payerReportIndices_[0] = 0;
+        payerReportIndices_[1] = 0;
+
+        uint32[] memory nodeIdsContainingNode1_ = new uint32[](3);
+        nodeIdsContainingNode1_[0] = 1;
+        nodeIdsContainingNode1_[1] = 2;
+        nodeIdsContainingNode1_[2] = 3;
+
+        uint32[] memory nodeIdsNotContainingNode1_ = new uint32[](2);
+        nodeIdsNotContainingNode1_[0] = 2;
+        nodeIdsNotContainingNode1_[1] = 3;
+
+        IPayerReportManagerLike.PayerReport[] memory payerReports_ = new IPayerReportManagerLike.PayerReport[](2);
+
+        payerReports_[0] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 0,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIdsContainingNode1_
+        });
+
+        payerReports_[1] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 0,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIdsNotContainingNode1_ // Node 1 is not in the second payer report.
+        });
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.mockCall(
+            _payerReportManager,
+            abi.encodeWithSignature("getPayerReports(uint32[],uint256[])", originatorNodeIds_, payerReportIndices_),
+            abi.encode(payerReports_)
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IDistributionManager.NotInPayerReport.selector, 3, 0));
+
+        vm.prank(_alice);
+        _manager.claim(1, originatorNodeIds_, payerReportIndices_);
+    }
+
+    function test_claim() external {
+        _manager.__setOwedFees(1, 300);
+        _manager.__setTotalOwedFees(500);
+
+        uint32[] memory originatorNodeIds_ = new uint32[](2);
+        originatorNodeIds_[0] = 2;
+        originatorNodeIds_[1] = 3;
+
+        uint256[] memory payerReportIndices_ = new uint256[](2);
+        payerReportIndices_[0] = 0;
+        payerReportIndices_[1] = 1;
+
+        uint32[] memory nodeIds_ = new uint32[](3);
+        nodeIds_[0] = 1;
+        nodeIds_[1] = 2;
+        nodeIds_[2] = 3;
+
+        IPayerReportManagerLike.PayerReport[] memory payerReports_ = new IPayerReportManagerLike.PayerReport[](2);
+
+        payerReports_[0] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 100,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIds_
+        });
+
+        payerReports_[1] = IPayerReportManagerLike.PayerReport({
+            startSequenceId: 0,
+            endSequenceId: 0,
+            feesSettled: 200,
+            offset: 0,
+            isSettled: true,
+            payersMerkleRoot: bytes32(0),
+            nodeIds: nodeIds_
+        });
+
+        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        Utils.expectAndMockCall(
+            _payerReportManager,
+            abi.encodeWithSignature("getPayerReports(uint32[],uint256[])", originatorNodeIds_, payerReportIndices_),
+            abi.encode(payerReports_)
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IDistributionManager.Claim(1, 2, 0, uint96(100) / 3);
+        emit IDistributionManager.Claim(1, 3, 1, uint96(200) / 3);
+
+        vm.prank(_alice);
+        uint96 claimed_ = _manager.claim(1, originatorNodeIds_, payerReportIndices_);
+
+        assertEq(claimed_, (uint96(100) / 3) + (uint96(200) / 3));
+        assertEq(_manager.getOwedFees(1), 300 + claimed_);
+        assertEq(_manager.totalOwedFees(), 500 + claimed_);
+        assertEq(_manager.getHasClaimed(1, 2, 0), true);
+        assertEq(_manager.getHasClaimed(1, 3, 1), true);
+    }
+
+    // TODO: Maybe a fuzz test for claim.
+
+    /* ============ withdraw ============ */
+
+    function test_withdraw_zeroDestination() external {
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.expectRevert(IDistributionManager.ZeroDestination.selector);
+
+        _manager.withdraw(1, address(0));
+    }
+
+    function test_withdraw_notNodeOwner() external {
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.expectRevert(IDistributionManager.NotNodeOwner.selector);
+
+        vm.prank(_bob);
+        _manager.withdraw(1, _bob);
+    }
+
+    function test_withdraw_noFeesOwed() external {
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        vm.expectRevert(IDistributionManager.NoFeesOwed.selector);
+
+        vm.prank(_alice);
+        _manager.withdraw(1, _alice);
+    }
+
+    function test_withdraw_zeroAvailableBalance() external {
+        _manager.__setOwedFees(1, 1);
+
+        vm.mockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+        vm.mockCall(_token, abi.encodeWithSignature("balanceOf(address)", address(_manager)), abi.encode(0));
+
+        vm.expectRevert(IDistributionManager.ZeroAvailableBalance.selector);
+
+        vm.prank(_alice);
+        _manager.withdraw(1, _alice);
+    }
+
+    function test_withdraw_partial() external {
+        _manager.__setOwedFees(1, 10);
+        _manager.__setTotalOwedFees(20);
+
+        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        Utils.expectAndMockCall(
+            _token,
+            abi.encodeWithSignature("balanceOf(address)", address(_manager)),
+            abi.encode(5)
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IDistributionManager.Withdrawal(1, 5);
+
+        vm.prank(_alice);
+        uint96 withdrawn_ = _manager.withdraw(1, _alice);
+
+        assertEq(withdrawn_, 5);
+        assertEq(_manager.getOwedFees(1), 5);
+        assertEq(_manager.totalOwedFees(), 15);
+    }
+
+    function test_withdraw_full() external {
+        _manager.__setOwedFees(1, 10);
+        _manager.__setTotalOwedFees(20);
+
+        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("ownerOf(uint256)", 1), abi.encode(_alice));
+
+        Utils.expectAndMockCall(
+            _token,
+            abi.encodeWithSignature("balanceOf(address)", address(_manager)),
+            abi.encode(10)
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IDistributionManager.Withdrawal(1, 10);
+
+        vm.prank(_alice);
+        uint96 withdrawn_ = _manager.withdraw(1, _alice);
+
+        assertEq(withdrawn_, 10);
+        assertEq(_manager.getOwedFees(1), 0);
+        assertEq(_manager.totalOwedFees(), 10);
+    }
+
+    /* ============ migrate ============ */
+
+    function test_migrate_zeroMigrator() external {
+        vm.expectRevert(IMigratable.ZeroMigrator.selector);
+        _manager.migrate();
+    }
+
+    function test_migrate_migrationFailed() external {
+        address migrator_ = address(new MockFailingMigrator());
+
+        Utils.expectAndMockParameterRegistryCall(
+            _parameterRegistry,
+            _MIGRATOR_KEY,
+            bytes32(uint256(uint160(migrator_)))
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMigratable.MigrationFailed.selector,
+                migrator_,
+                abi.encodeWithSelector(MockFailingMigrator.Failed.selector)
+            )
+        );
+
+        _manager.migrate();
+    }
+
+    function test_migrate_emptyCode() external {
+        Utils.expectAndMockParameterRegistryCall(
+            _parameterRegistry,
+            _MIGRATOR_KEY,
+            bytes32(uint256(uint160(address(1))))
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IMigratable.EmptyCode.selector, address(1)));
+
+        _manager.migrate();
+    }
+
+    function test_migrate() external {
+        _manager.__setOwedFees(1, 2);
+        _manager.__setHasClaimed(1, 2, 0, true);
+
+        address newImplementation_ = address(
+            new DistributionManagerHarness(_parameterRegistry, _nodeRegistry, _payerReportManager, _token)
+        );
+
+        address migrator_ = address(new MockMigrator(newImplementation_));
+
+        Utils.expectAndMockParameterRegistryCall(
+            _parameterRegistry,
+            _MIGRATOR_KEY,
+            bytes32(uint256(uint160(migrator_)))
+        );
+
+        vm.expectEmit(address(_manager));
+        emit IMigratable.Migrated(migrator_);
+
+        vm.expectEmit(address(_manager));
+        emit IERC1967.Upgraded(newImplementation_);
+
+        _manager.migrate();
+
+        assertEq(Utils.getImplementationFromSlot(address(_manager)), newImplementation_);
+        assertEq(_manager.parameterRegistry(), _parameterRegistry);
+        assertEq(_manager.nodeRegistry(), _nodeRegistry);
+        assertEq(_manager.payerReportManager(), _payerReportManager);
+        assertEq(_manager.token(), _token);
+
+        assertEq(_manager.getOwedFees(1), 2);
+        assertEq(_manager.getHasClaimed(1, 2, 0), true);
+    }
+
+    /* ============ totalOwedFees ============ */
+
+    function test_totalOwedFees() external {
+        _manager.__setTotalOwedFees(1);
+
+        assertEq(_manager.totalOwedFees(), 1);
+
+        _manager.__setTotalOwedFees(100);
+
+        assertEq(_manager.totalOwedFees(), 100);
+    }
+
+    /* ============ getOwedFees ============ */
+
+    function test_getOwedFees() external {
+        _manager.__setOwedFees(1, 2);
+        _manager.__setOwedFees(3, 4);
+
+        assertEq(_manager.getOwedFees(1), 2);
+        assertEq(_manager.getOwedFees(3), 4);
+    }
+
+    /* ============ getHasClaimed ============ */
+
+    function test_getHasClaimed() external {
+        _manager.__setHasClaimed(1, 2, 0, true);
+        _manager.__setHasClaimed(1, 2, 1, false);
+        _manager.__setHasClaimed(1, 3, 0, true);
+
+        _manager.__setHasClaimed(2, 2, 0, false);
+        _manager.__setHasClaimed(2, 2, 1, true);
+        _manager.__setHasClaimed(2, 3, 0, false);
+
+        assertEq(_manager.getHasClaimed(1, 2, 0), true);
+        assertEq(_manager.getHasClaimed(1, 2, 1), false);
+        assertEq(_manager.getHasClaimed(1, 3, 0), true);
+
+        assertEq(_manager.getHasClaimed(2, 2, 0), false);
+        assertEq(_manager.getHasClaimed(2, 2, 1), true);
+        assertEq(_manager.getHasClaimed(2, 3, 0), false);
+    }
+}

--- a/test/unit/GroupMessageBroadcaster.t.sol
+++ b/test/unit/GroupMessageBroadcaster.t.sol
@@ -152,10 +152,10 @@ contract GroupMessageBroadcasterTests is Test {
         uint64 sequenceId_,
         bool paused_
     ) external {
-        minPayloadSize_ = bound(minPayloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
-        maxPayloadSize_ = bound(maxPayloadSize_, minPayloadSize_, _STARTING_MAX_PAYLOAD_SIZE);
-        payloadSize_ = bound(payloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
-        sequenceId_ = uint64(bound(sequenceId_, 0, type(uint64).max - 1));
+        minPayloadSize_ = _bound(minPayloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
+        maxPayloadSize_ = _bound(maxPayloadSize_, minPayloadSize_, _STARTING_MAX_PAYLOAD_SIZE);
+        payloadSize_ = _bound(payloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
+        sequenceId_ = uint64(_bound(sequenceId_, 0, type(uint64).max - 1));
 
         _broadcaster.__setSequenceId(sequenceId_);
         _broadcaster.__setMinPayloadSize(minPayloadSize_);

--- a/test/unit/IdentityUpdateBroadcaster.t.sol
+++ b/test/unit/IdentityUpdateBroadcaster.t.sol
@@ -154,10 +154,10 @@ contract IdentityUpdateBroadcasterTests is Test {
         uint64 sequenceId_,
         bool paused_
     ) external {
-        minPayloadSize_ = bound(minPayloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
-        maxPayloadSize_ = bound(maxPayloadSize_, minPayloadSize_, _STARTING_MAX_PAYLOAD_SIZE);
-        payloadSize_ = bound(payloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
-        sequenceId_ = uint64(bound(sequenceId_, 0, type(uint64).max - 1));
+        minPayloadSize_ = _bound(minPayloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
+        maxPayloadSize_ = _bound(maxPayloadSize_, minPayloadSize_, _STARTING_MAX_PAYLOAD_SIZE);
+        payloadSize_ = _bound(payloadSize_, 1, _STARTING_MAX_PAYLOAD_SIZE);
+        sequenceId_ = uint64(_bound(sequenceId_, 0, type(uint64).max - 1));
 
         _broadcaster.__setSequenceId(sequenceId_);
         _broadcaster.__setMinPayloadSize(minPayloadSize_);

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -472,8 +472,9 @@ contract DistributionManagerHarness is DistributionManager {
         address parameterRegistry_,
         address nodeRegistry_,
         address payerReportManager_,
+        address payerRegistry_,
         address token_
-    ) DistributionManager(parameterRegistry_, nodeRegistry_, payerReportManager_, token_) {}
+    ) DistributionManager(parameterRegistry_, nodeRegistry_, payerReportManager_, payerRegistry_, token_) {}
 
     function __setOwedFees(uint256 nodeId_, uint256 owedFees_) external {
         _getDistributionManagerStorage().owedFees[uint32(nodeId_)] = uint96(owedFees_);

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -18,6 +18,7 @@ import { RateRegistry } from "../../src/settlement-chain/RateRegistry.sol";
 import { SettlementChainGateway } from "../../src/settlement-chain/SettlementChainGateway.sol";
 import { SettlementChainParameterRegistry } from "../../src/settlement-chain/SettlementChainParameterRegistry.sol";
 import { PayerReportManager } from "../../src/settlement-chain/PayerReportManager.sol";
+import { DistributionManager } from "../../src/settlement-chain/DistributionManager.sol";
 
 contract PayloadBroadcasterHarness is PayloadBroadcaster {
     constructor(address parameterRegistry_) PayloadBroadcaster(parameterRegistry_) {}
@@ -463,5 +464,33 @@ contract PayerReportManagerHarness is PayerReportManager {
         bytes calldata signature_
     ) external view returns (bool isValid_) {
         return _verifySignature(digest_, nodeId_, signature_);
+    }
+}
+
+contract DistributionManagerHarness is DistributionManager {
+    constructor(
+        address parameterRegistry_,
+        address nodeRegistry_,
+        address payerReportManager_,
+        address token_
+    ) DistributionManager(parameterRegistry_, nodeRegistry_, payerReportManager_, token_) {}
+
+    function __setOwedFees(uint256 nodeId_, uint256 owedFees_) external {
+        _getDistributionManagerStorage().owedFees[uint32(nodeId_)] = uint96(owedFees_);
+    }
+
+    function __setTotalOwedFees(uint256 totalOwedFees_) external {
+        _getDistributionManagerStorage().totalOwedFees = uint96(totalOwedFees_);
+    }
+
+    function __setHasClaimed(
+        uint256 nodeId_,
+        uint256 originatorNodeId_,
+        uint256 payerReportIndex_,
+        bool hasClaimed_
+    ) external {
+        _getDistributionManagerStorage().hasClaimed[uint32(nodeId_)][uint32(originatorNodeId_)][
+            payerReportIndex_
+        ] = hasClaimed_;
     }
 }

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -79,6 +79,7 @@ contract MockERC20Inbox {
 
 contract MockNodeRegistry {
     uint8 public canonicalNodesCount;
+    mapping(uint256 tokenId => address owner) public ownerOf;
 
     function getIsCanonicalNode(uint32 nodeId_) external view returns (bool isCanonicalNode_) {
         return true;
@@ -94,4 +95,21 @@ contract MockPayerRegistry {
     }
 
     function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_) {}
+}
+
+contract MockPayerReportManager {
+    struct PayerReport {
+        uint32 startSequenceId;
+        uint32 endSequenceId;
+        uint96 feesSettled;
+        uint32 offset;
+        bool isSettled;
+        bytes32 payersMerkleRoot;
+        uint32[] nodeIds;
+    }
+
+    function getPayerReports(
+        uint32[] calldata originatorNodeIds_,
+        uint256[] calldata payerReportIndices_
+    ) external view returns (PayerReport[] memory payerReports_) {}
 }

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -95,6 +95,8 @@ contract MockPayerRegistry {
     }
 
     function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_) {}
+
+    function sendExcessToFeeDistributor() external returns (uint96 excess_) {}
 }
 
 contract MockPayerReportManager {


### PR DESCRIPTION
- `PayerReportManager.getPayerReports` changed to query an array of originator nodeIds and payer report indices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a contract for managing and distributing fees to node owners, including claiming and withdrawing owed fees.
  - Added interfaces and events to support fee claim tracking and secure withdrawals.
  - Provided migration support for future upgrades.

- **Enhancements**
  - Updated report retrieval functions to support batch queries and improved error handling for mismatched input arrays.
  - Extended interfaces to improve compatibility and ownership verification.

- **Bug Fixes**
  - Improved test coverage for error cases and state transitions in fee distribution and report management.

- **Tests**
  - Added comprehensive tests for fee claiming, withdrawal, migration, and edge cases.
  - Introduced new test harnesses and mock contracts to facilitate robust testing.

- **Chores**
  - Updated configuration by removing an unused linting rule.

- **CI**
  - Added a fixed fuzzing seed to improve determinism in gas report testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->