### PR TITLE
fix: sequence ids are uint64

### DIFF
--- a/src/settlement-chain/PayerReportManager.sol
+++ b/src/settlement-chain/PayerReportManager.sol
@@ -26,8 +26,8 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
     /* ============ Constants/Immutables ============ */
 
     // solhint-disable-next-line max-line-length
-    /// @dev keccak256("PayerReport(uint32 originatorNodeId,uint32 startSequenceId,uint32 endSequenceId,bytes32 payersMerkleRoot,uint32[] nodeIds)")
-    bytes32 public constant PAYER_REPORT_TYPEHASH = 0xfbb9f0351ed83428cdf60d26ec3b535e6e16daff660a48308d7e0c22c53fba78;
+    /// @dev keccak256("PayerReport(uint32 originatorNodeId,uint64 startSequenceId,uint64 endSequenceId,bytes32 payersMerkleRoot,uint32[] nodeIds)")
+    bytes32 public constant PAYER_REPORT_TYPEHASH = 0x30503e47cf573d37e2be5212eb8a3f06caca0f3ab0d379e7d05758b47b23d658;
 
     /// @inheritdoc IPayerReportManager
     address public immutable parameterRegistry;
@@ -91,8 +91,8 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
     /// @inheritdoc IPayerReportManager
     function submit(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_,
         PayerReportSignature[] calldata signatures_
@@ -103,7 +103,7 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
 
         payerReportIndex_ = payerReports_.length;
 
-        uint32 lastSequenceId_ = payerReportIndex_ > 0 ? payerReports_[payerReportIndex_ - 1].endSequenceId : 0;
+        uint64 lastSequenceId_ = payerReportIndex_ > 0 ? payerReports_[payerReportIndex_ - 1].endSequenceId : 0;
 
         // Enforces that the start sequence ID is the last end sequence ID.
         if (startSequenceId_ != lastSequenceId_) {
@@ -214,8 +214,8 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
     /// @inheritdoc IPayerReportManager
     function getPayerReportDigest(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_
     ) external view returns (bytes32 digest_) {
@@ -269,9 +269,9 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
      * @return digest_           The EIP-712 digest.
      */
     function _getPayerReportDigest(
-        uint256 originatorNodeId_,
-        uint256 startSequenceId_,
-        uint256 endSequenceId_,
+        uint32 originatorNodeId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_
     ) internal view returns (bytes32 digest_) {
@@ -300,8 +300,8 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
      */
     function _verifySignatures(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_,
         PayerReportSignature[] calldata signatures_

--- a/src/settlement-chain/interfaces/External.sol
+++ b/src/settlement-chain/interfaces/External.sol
@@ -115,8 +115,8 @@ interface IPayerRegistryLike {
  */
 interface IPayerReportManagerLike {
     struct PayerReport {
-        uint32 startSequenceId;
-        uint32 endSequenceId;
+        uint64 startSequenceId;
+        uint64 endSequenceId;
         uint96 feesSettled;
         uint32 offset;
         bool isSettled;

--- a/src/settlement-chain/interfaces/IPayerReportManager.sol
+++ b/src/settlement-chain/interfaces/IPayerReportManager.sol
@@ -24,8 +24,8 @@ interface IPayerReportManager is IMigratable, IERC5267, IRegistryParametersError
      * @param  nodeIds          The active node IDs during the reporting period.
      */
     struct PayerReport {
-        uint32 startSequenceId;
-        uint32 endSequenceId;
+        uint64 startSequenceId;
+        uint64 endSequenceId;
         uint96 feesSettled;
         uint32 offset;
         bool isSettled;
@@ -58,8 +58,8 @@ interface IPayerReportManager is IMigratable, IERC5267, IRegistryParametersError
     event PayerReportSubmitted(
         uint32 indexed originatorNodeId,
         uint256 indexed payerReportIndex,
-        uint32 startSequenceId,
-        uint32 indexed endSequenceId,
+        uint64 startSequenceId,
+        uint64 indexed endSequenceId,
         bytes32 payersMerkleRoot,
         uint32[] nodeIds,
         uint32[] signingNodeIds
@@ -93,7 +93,7 @@ interface IPayerReportManager is IMigratable, IERC5267, IRegistryParametersError
     error ZeroPayerRegistry();
 
     /// @notice Thrown when the start sequence ID is not the last end sequence ID.
-    error InvalidStartSequenceId(uint32 startSequenceId, uint32 lastSequenceId);
+    error InvalidStartSequenceId(uint64 startSequenceId, uint64 lastSequenceId);
 
     /// @notice Thrown when the start and end sequence IDs are invalid.
     error InvalidSequenceIds();
@@ -137,8 +137,8 @@ interface IPayerReportManager is IMigratable, IERC5267, IRegistryParametersError
      */
     function submit(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_,
         PayerReportSignature[] calldata signatures_
@@ -210,8 +210,8 @@ interface IPayerReportManager is IMigratable, IERC5267, IRegistryParametersError
      */
     function getPayerReportDigest(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_
     ) external view returns (bytes32 digest_);

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -916,7 +916,7 @@ contract PayerReportManagerTests is Test {
                 payersMerkleRoot_: bytes32(uint256(4)),
                 nodeIds_: new uint32[](5)
             }),
-            0x4cf04a8aee0f79c7a8ca56676533991601c857b8c4d5311d4d48d3626a481c21
+            0x7ee285f7b9ef917539bee4149484c08415ecdc7532763230f366ba4c5881f6cf
         );
 
         assertEq(
@@ -927,7 +927,7 @@ contract PayerReportManagerTests is Test {
                 payersMerkleRoot_: bytes32(uint256(40)),
                 nodeIds_: new uint32[](50)
             }),
-            0x03762966f4c0a81b51620453d64965d2d7a8bc612d228a7e4f5aed595b1af7ef
+            0xa83b4d83dbbcece40b01dd738ad4d8636714bf0ef6c047ec58b9192bdaf8e72d
         );
     }
 
@@ -1065,7 +1065,7 @@ contract PayerReportManagerTests is Test {
         assertEq(
             _manager.PAYER_REPORT_TYPEHASH(),
             keccak256(
-                "PayerReport(uint32 originatorNodeId,uint32 startSequenceId,uint32 endSequenceId,bytes32 payersMerkleRoot,uint32[] nodeIds)"
+                "PayerReport(uint32 originatorNodeId,uint64 startSequenceId,uint64 endSequenceId,bytes32 payersMerkleRoot,uint32[] nodeIds)"
             )
         );
     }
@@ -1096,8 +1096,8 @@ contract PayerReportManagerTests is Test {
 
     function _getPayerReportSignature(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] memory nodeIds_,
         uint256 privateKey_

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -931,6 +931,29 @@ contract PayerReportManagerTests is Test {
         );
     }
 
+    function test_getPayerReportDigest_sample1() external view {
+        bytes32 payersMerkleRoot_ = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+
+        uint32[] memory nodeIds_ = new uint32[](5);
+
+        nodeIds_[0] = 100;
+        nodeIds_[1] = 200;
+        nodeIds_[2] = 300;
+        nodeIds_[3] = 400;
+        nodeIds_[4] = 500;
+
+        assertEq(
+            _manager.getPayerReportDigest({
+                originatorNodeId_: 1,
+                startSequenceId_: 2,
+                endSequenceId_: 3,
+                payersMerkleRoot_: payersMerkleRoot_,
+                nodeIds_: nodeIds_
+            }),
+            0x1ec269bb27455a17e615c98f34f05a635943526e8fddff7b6a81a73bb1468b9c
+        );
+    }
+
     /* ============ getPayerReports ============ */
 
     function test_getPayerReports_arrayLengthMismatch() external {

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -420,8 +420,8 @@ contract PayerReportManagerHarness is PayerReportManager {
 
     function __pushPayerReport(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         uint96 feesSettled_,
         uint32 offset_,
         bool isSettled_,
@@ -443,8 +443,8 @@ contract PayerReportManagerHarness is PayerReportManager {
 
     function __verifySignatures(
         uint32 originatorNodeId_,
-        uint32 startSequenceId_,
-        uint32 endSequenceId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
         bytes32 payersMerkleRoot_,
         uint32[] calldata nodeIds_,
         PayerReportSignature[] calldata signatures_


### PR DESCRIPTION
### Expand sequence ID data type from uint32 to uint64 in PayerReportManager contract and related interfaces to increase maximum sequence ID value from 4.3 billion to 18.4 quintillion
Updates data types for sequence IDs across multiple contract files:
* Changes sequence ID type from `uint32` to `uint64` in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/72/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9), including `PAYER_REPORT_TYPEHASH`, `submit()`, and internal functions
* Updates `PayerReport` struct fields and interface definitions in [External.sol](https://github.com/xmtp/smart-contracts/pull/72/files#diff-1596a253d607e4794c2d1ea4547a3d43dbbd47709f8cea30dc4f06f9de5f1fef) and [IPayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/72/files#diff-9fb0d383a957303659dfce9466a61de006a70c84e9d00bcc77e77d2cb559dd16)
* Modifies test assertions and type strings in [PayerReportManager.t.sol](https://github.com/xmtp/smart-contracts/pull/72/files#diff-88d841009e835b92dfaa91cbaaca83627d59bcb7e62090ff6a6af09f7ee67bdb) and test harnesses in [Harnesses.sol](https://github.com/xmtp/smart-contracts/pull/72/files#diff-f803a3747dfd9bb6151512e75424166315fd4e6c591066540f3f690ec7093177)

#### 📍Where to Start
Start with the `PayerReport` struct definition and `PAYER_REPORT_TYPEHASH` changes in [IPayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/72/files#diff-9fb0d383a957303659dfce9466a61de006a70c84e9d00bcc77e77d2cb559dd16), as this interface defines the core data structures affected by the sequence ID type change.

----

_[Macroscope](https://app.macroscope.com) summarized 1562336._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased the supported range for sequence IDs in payer reports, allowing for larger values.

- **Tests**
  - Updated tests to reflect the expanded sequence ID range and ensure compatibility with the new data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->