### PR TITLE
Fix xmtp contracts image generation

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && \
 
 USER foundry
 
+ENV ANVIL_RPC_URL=http://localhost:8545
+
 # Copy your project files into the image
 COPY . .
 

--- a/dev/gen-anvil-state
+++ b/dev/gen-anvil-state
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+script_dir=$(dirname "$(realpath "$0")")
+repo_root=$(realpath "${script_dir}/../")
+cd "${repo_root}"
+
+export ANVIL_RPC_URL=http://localhost:8545
+
 # anvil first well-known private key
 export LOCAL_DEPLOY_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
@@ -17,8 +23,7 @@ kill_anvil
 
 # Step 2: Start anvil in the background
 echo "▶ Starting anvil..."
-npm run anvil &
-
+anvil --dump-state anvil-state.json &> /dev/null 2>&1 &
 sleep 1
 
 # Step 3: Run deploy-local
@@ -26,6 +31,6 @@ echo "▶ Running deploy-local..."
 npm run deploy-local
 
 # Step 4: Wait a bit for anvil to write to disk
-sleep 1
+sleep 5
 
 kill_anvil


### PR DESCRIPTION
### Configure XMTP contracts image generation by adding Anvil RPC URL and improving state file handling in Docker environment
* Adds `ANVIL_RPC_URL=http://localhost:8545` environment variable in [dev/Dockerfile](https://github.com/xmtp/smart-contracts/pull/76/files#diff-dc2e86802a20a9eb13f8ddd90914fd044e84f7e49486fe84ccf0cf28c10989a8) for foundry user configuration
* Modifies [dev/gen-anvil-state](https://github.com/xmtp/smart-contracts/pull/76/files#diff-2aece676bd12eb1ed85edacb14dbe394d13936ba80ac904a48a6e38df18451dd) script to use direct `anvil` command with `--dump-state` parameter instead of npm scripts
* Increases state file write delay from 1 to 5 seconds after deploy-local execution
* Introduces environment variables for dev directory paths and anvil state file location

#### 📍Where to Start
Start with the [dev/gen-anvil-state](https://github.com/xmtp/smart-contracts/pull/76/files#diff-2aece676bd12eb1ed85edacb14dbe394d13936ba80ac904a48a6e38df18451dd) script which contains the core changes to the Anvil state generation process and environment configuration.

----

_[Macroscope](https://app.macroscope.com) summarized d925794._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker environment to include a new environment variable for local RPC URL configuration.
  - Improved development script to enhance environment setup, directly invoke Anvil with state dumping, and ensure reliable state file creation with an increased wait time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->