### PR TITLE
Update canonical for local deploy

### DIFF
--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -634,9 +634,11 @@ contract DeployLocal is Script {
     function _updateNodeRegistryStartingParameters() internal {
         vm.startBroadcast(_privateKey);
         _nodeRegistryProxy.updateAdmin();
+        _nodeRegistryProxy.updateMaxCanonicalNodes();
         vm.stopBroadcast();
 
         if (_nodeRegistryProxy.admin() != _admin) revert("Node registry admin not updated correctly");
+        if (_nodeRegistryProxy.maxCanonicalNodes() != _NODE_REGISTRY_STARTING_MAX_CANONICAL_NODES) revert("Node registry max canonical not updated correctly");
     }
 
     /* ============ Payer Report Manager Helpers ============ */

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -638,7 +638,8 @@ contract DeployLocal is Script {
         vm.stopBroadcast();
 
         if (_nodeRegistryProxy.admin() != _admin) revert("Node registry admin not updated correctly");
-        if (_nodeRegistryProxy.maxCanonicalNodes() != _NODE_REGISTRY_STARTING_MAX_CANONICAL_NODES) revert("Node registry max canonical not updated correctly");
+        if (_nodeRegistryProxy.maxCanonicalNodes() != _NODE_REGISTRY_STARTING_MAX_CANONICAL_NODES)
+            revert("Node registry max canonical not updated correctly");
     }
 
     /* ============ Payer Report Manager Helpers ============ */


### PR DESCRIPTION
### Add maxCanonicalNodes update and validation to DeployLocal script to configure node registry parameters during local deployment
The `_updateNodeRegistryStartingParameters()` function in [DeployLocal.s.sol](https://github.com/xmtp/smart-contracts/pull/78/files#diff-e96b37df7ba56f935870323c6570db5fe67fb13ee0d7bca208f693ea3b9d080a) now includes functionality to update and validate the maximum number of canonical nodes. The script adds a call to `_nodeRegistryProxy.updateMaxCanonicalNodes()` and validates that the `maxCanonicalNodes` value matches the `_NODE_REGISTRY_STARTING_MAX_CANONICAL_NODES` constant.

#### 📍Where to Start
Start with the `_updateNodeRegistryStartingParameters()` function in [DeployLocal.s.sol](https://github.com/xmtp/smart-contracts/pull/78/files#diff-e96b37df7ba56f935870323c6570db5fe67fb13ee0d7bca208f693ea3b9d080a) which contains the new canonical node configuration logic.

----

_[Macroscope](https://app.macroscope.com) summarized 11bcfe3._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the update and validation process for the maximum number of canonical nodes during deployment, ensuring more reliable configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->