### PR TITLE
Generate SettlementChainParameterRegistry ABI

### DIFF
--- a/dev/gen-artifacts
+++ b/dev/gen-artifacts
@@ -333,7 +333,7 @@ function main() {
         generate_artifacts "app-chain" "${contract}"
     done
 
-    contracts=("NodeRegistry" "RateRegistry" "PayerRegistry" "PayerReportManager")
+    contracts=("NodeRegistry" "RateRegistry" "PayerRegistry" "PayerReportManager" "SettlementChainParameterRegistry")
     for contract in "${contracts[@]}"; do
         echo "⧖ Generating artifacts for contract: ${contract}"
         generate_artifacts "settlement-chain" "${contract}"


### PR DESCRIPTION
### Add SettlementChainParameterRegistry to settlement-chain artifact generation to enable ABI generation
Adds `SettlementChainParameterRegistry` contract to the list of contracts for which artifacts are generated in the settlement-chain build process.

#### 📍Where to Start
Review the build configuration file where the contract list is modified to include `SettlementChainParameterRegistry` in the settlement-chain artifact generation process.

----

_[Macroscope](https://app.macroscope.com) summarized 74efea2._