### PR TITLE
fix: check zero implementation on `deployProxy`

### DIFF
--- a/src/any-chain/Factory.sol
+++ b/src/any-chain/Factory.sol
@@ -53,6 +53,8 @@ contract Factory is IFactory {
         bytes32 salt_,
         bytes calldata initializeCallData_
     ) external returns (address proxy_) {
+        if (implementation_ == address(0)) revert InvalidImplementation();
+
         // Append the initializable implementation address as a constructor argument to the proxy deploy code, and use
         // the sender's address combined with their chosen salt as the final salt.
         proxy_ = _create2(

--- a/src/any-chain/interfaces/IFactory.sol
+++ b/src/any-chain/interfaces/IFactory.sol
@@ -40,6 +40,9 @@ interface IFactory {
 
     /* ============ Custom Errors ============ */
 
+    /// @notice Thrown when the implementation is the zero address.
+    error InvalidImplementation();
+
     /// @notice Thrown when the bytecode is empty (i.e. of the implementation to deploy).
     error EmptyBytecode();
 

--- a/test/unit/Factory.t.sol
+++ b/test/unit/Factory.t.sol
@@ -84,6 +84,11 @@ contract FactoryTests is Test {
 
     /* ============ deployProxy ============ */
 
+    function test_deployProxy_invalidImplementation() external {
+        vm.expectRevert(IFactory.InvalidImplementation.selector);
+        _factory.deployProxy(address(0), 0, "");
+    }
+
     function test_deployProxy_deployFailed() external {
         address foo_ = address(new Foo(uint256(456), uint256(789)));
 


### PR DESCRIPTION
### Add zero address validation check to `deployProxy` function in Factory contract to prevent invalid implementations
* Adds input validation in [Factory.sol](https://github.com/xmtp/smart-contracts/pull/81/files#diff-9de302a94bf05d441b996dbb5edad0d467196856b482287496b07106d3aa5de0) to prevent deploying proxies with zero address implementations
* Introduces new `InvalidImplementation` custom error in [IFactory.sol](https://github.com/xmtp/smart-contracts/pull/81/files#diff-b11fe1579901200a38ca7da7053e10fe9d4439e582a2889b328231bab7fda1e9)
* Includes unit test in [Factory.t.sol](https://github.com/xmtp/smart-contracts/pull/81/files#diff-781ef2c7126a33b9c66c5e1b6021b278ede0ab2d83ed44e63e687cc14160ffd1) to verify zero address implementation handling

#### 📍Where to Start
Start with the `deployProxy` function in [Factory.sol](https://github.com/xmtp/smart-contracts/pull/81/files#diff-9de302a94bf05d441b996dbb5edad0d467196856b482287496b07106d3aa5de0) where the zero address validation check has been added.

----

_[Macroscope](https://app.macroscope.com) summarized 3f054be._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a validation to prevent deploying a proxy with an invalid (zero) implementation address, improving contract safety.
- **Tests**
  - Introduced a new test to ensure deploying with an invalid implementation address correctly triggers an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->