### PR TITLE
fix: foundry exact version

### DIFF
--- a/dev/gen-artifacts
+++ b/dev/gen-artifacts
@@ -86,8 +86,8 @@ function main() {
     echo -e "\033[32m✔\033[0m Artifacts generated successfully!\n"
 }
 
-if [ "${forge_version}" != "1.1.0" ]; then
-    echo "ERROR: Forge version must be 1.1.0. Got '${forge_version}'" >&2
+if [ "${forge_version}" != "1.2.0" ]; then
+    echo "ERROR: Forge version must be 1.2.0. Got '${forge_version}'" >&2
     exit 1
 fi
 


### PR DESCRIPTION
### Update forge version requirement from 1.1.0 to 1.2.0 in dev/gen-artifacts script
The script modifies the version validation logic to require forge version 1.2.0 instead of the previous 1.1.0 requirement. The error message displayed when an incorrect version is detected has been updated to reflect this new version requirement in [dev/gen-artifacts](https://github.com/xmtp/smart-contracts/pull/82/files#diff-33bf293136c4382327860fd4266724b6e6e4dca3a59b9e391156647a6516b214).

#### 📍Where to Start
Start with the version check logic in [dev/gen-artifacts](https://github.com/xmtp/smart-contracts/pull/82/files#diff-33bf293136c4382327860fd4266724b6e6e4dca3a59b9e391156647a6516b214) script where the forge version validation occurs.

----

_[Macroscope](https://app.macroscope.com) summarized 93cbe1f._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the required Forge version to 1.2.0 in the script's version check and error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->