### PR TITLE
Run CI on branch and main

### DIFF
--- a/.github/workflows/release-from-tag.yml
+++ b/.github/workflows/release-from-tag.yml
@@ -41,7 +41,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=ref,event=tag
             type=sha
             type=semver,pattern={{version}},event=tag
 

--- a/.github/workflows/release-from-tag.yml
+++ b/.github/workflows/release-from-tag.yml
@@ -2,12 +2,15 @@ name: Release from tag
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
+  pull_request:
 
 jobs:
   anvil-image:
-    name: Build and publish Anvil Docker image
+    name: Build (and publish) Anvil Docker image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,8 +37,13 @@ jobs:
         with:
           images: ghcr.io/xmtp/contracts
           tags: |
+            type=schedule
+            type=ref,event=branch
             type=ref,event=tag
-            type=semver,pattern={{version}}
+            type=ref,event=pr
+            type=ref,event=tag
+            type=sha
+            type=semver,pattern={{version}},event=tag
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -66,7 +74,14 @@ jobs:
           BUILD_TAG: ${{ github.ref_name }}
         run: dev/gen-artifacts
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ github.run_id }}
+          path: ./artifacts
+
       - name: Create GitHub Release with artifacts
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: ./artifacts/**/*


### PR DESCRIPTION
### Expand GitHub workflow to run CI on branch and main pushes in addition to tag events
The GitHub workflow [.github/workflows/release-from-tag.yml](https://github.com/xmtp/smart-contracts/pull/83/files#diff-cee4eadd46d2585fd337f530116877504920be9ec452bdbfb915b95857438208) now triggers on pushes to the `main` branch and pull requests in addition to tag events. The workflow adds multiple Docker image tagging strategies including `type=ref,event=branch`, `type=ref,event=pr`, and `type=sha` for different event types, while restricting semver tagging to tag events only. Build artifacts are uploaded for all workflow runs using `actions/upload-artifact@v4`, and GitHub Release creation is made conditional with `if: startsWith(github.ref, 'refs/tags/')` to only occur for tag events.

#### 📍Where to Start
Start with the workflow trigger configuration at the top of [.github/workflows/release-from-tag.yml](https://github.com/xmtp/smart-contracts/pull/83/files#diff-cee4eadd46d2585fd337f530116877504920be9ec452bdbfb915b95857438208) to understand the new event conditions.

----

_[Macroscope](https://app.macroscope.com) summarized e69c9e1._