### PR TITLE
feat: enforce public key format

### DIFF
--- a/src/settlement-chain/NodeRegistry.sol
+++ b/src/settlement-chain/NodeRegistry.sol
@@ -99,7 +99,6 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
         string calldata httpAddress_
     ) external onlyAdmin returns (uint32 nodeId_, address signer_) {
         if (_isZero(owner_)) revert InvalidOwner();
-        if (signingPublicKey_.length == 0) revert InvalidSigningPublicKey();
         if (bytes(httpAddress_).length == 0) revert InvalidHttpAddress();
 
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
@@ -110,7 +109,7 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
             nodeId_ = ++$.nodeCount * NODE_INCREMENT; // The first node starts with `nodeId_ = NODE_INCREMENT`.
         }
 
-        signer_ = address(uint160(uint256(keccak256(signingPublicKey_))));
+        signer_ = _getSignerFromPublicKey(signingPublicKey_);
 
         // Nodes start off as non-canonical.
         $.nodes[nodeId_] = Node(signer_, false, signingPublicKey_, httpAddress_);
@@ -269,6 +268,12 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
 
     function _baseURI() internal view override returns (string memory baseURI_) {
         return _getNodeRegistryStorage().baseURI;
+    }
+
+    function _getSignerFromPublicKey(bytes calldata publicKey_) internal pure returns (address signer_) {
+        if (publicKey_.length != 65 || bytes1(publicKey_[:1]) != 0x04) revert InvalidSigningPublicKey();
+
+        return address(uint160(uint256(keccak256(publicKey_[1:65]))));
     }
 
     function _isZero(address input_) internal pure returns (bool isZero_) {

--- a/src/settlement-chain/NodeRegistry.sol
+++ b/src/settlement-chain/NodeRegistry.sol
@@ -270,6 +270,12 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
         return _getNodeRegistryStorage().baseURI;
     }
 
+    /**
+     * @notice Returns the signer address from a public key.
+     * @param  publicKey_ The public key.
+     * @return signer_    The signer address.
+     * @dev    Validates uncompressed public key format: 0x04 + 32 bytes X + 32 bytes Y = 65 bytes total
+     */
     function _getSignerFromPublicKey(bytes calldata publicKey_) internal pure returns (address signer_) {
         if (publicKey_.length != 65 || bytes1(publicKey_[:1]) != 0x04) revert InvalidSigningPublicKey();
 

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -35,21 +35,17 @@ contract PayerReportManagerTests is Test {
     address internal _parameterRegistry = makeAddr("parameterRegistry");
     address internal _payerRegistry = makeAddr("payerRegistry");
 
-    address internal _signer1;
-    uint256 internal _signer1Pk;
-    address internal _signer2;
-    uint256 internal _signer2Pk;
-    address internal _signer3;
-    uint256 internal _signer3Pk;
-    address internal _signer4;
-    uint256 internal _signer4Pk;
+    address internal _signer1 = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address internal _signer2 = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+    address internal _signer3 = 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC;
+    address internal _signer4 = 0x90F79bf6EB2c4f870365E785982E1f101E93b906;
+
+    uint256 internal _signer1Pk = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
+    uint256 internal _signer2Pk = uint256(0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d);
+    uint256 internal _signer3Pk = uint256(0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a);
+    uint256 internal _signer4Pk = uint256(0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6);
 
     function setUp() external {
-        (_signer1, _signer1Pk) = makeAddrAndKey("signer1");
-        (_signer2, _signer2Pk) = makeAddrAndKey("signer2");
-        (_signer3, _signer3Pk) = makeAddrAndKey("signer3");
-        (_signer4, _signer4Pk) = makeAddrAndKey("signer4");
-
         _implementation = address(new PayerReportManagerHarness(_parameterRegistry, _nodeRegistry, _payerRegistry));
         _manager = PayerReportManagerHarness(address(new Proxy(_implementation)));
 


### PR DESCRIPTION
### Enforce public key format validation requiring 65-byte length and 0x04 prefix in NodeRegistry.addNode function
The `NodeRegistry.addNode` function now validates that signing public keys are exactly 65 bytes long and start with 0x04 prefix through a new `_getSignerFromPublicKey` internal function in [NodeRegistry.sol](https://github.com/xmtp/smart-contracts/pull/84/files#diff-4059215632391073d4048ae397284d2a9cc5727794ad78c69b3e14476319aafb). The validation logic replaces the previous empty key check and handles signer address calculation. Test suites in [NodeRegistry.t.sol](https://github.com/xmtp/smart-contracts/pull/84/files#diff-048b25e6c47ed8a12fec70597c3601ac95ce99ed773ebceb9b13f15694a5c979) and [PayerReportManager.t.sol](https://github.com/xmtp/smart-contracts/pull/84/files#diff-88d841009e835b92dfaa91cbaaca83627d59bcb7e62090ff6a6af09f7ee67bdb) now use hardcoded Ethereum addresses and keys instead of dynamically generated ones, with new test cases covering invalid public key format scenarios.

#### 📍Where to Start
Start with the `addNode` function in [NodeRegistry.sol](https://github.com/xmtp/smart-contracts/pull/84/files#diff-4059215632391073d4048ae397284d2a9cc5727794ad78c69b3e14476319aafb) to see how the new `_getSignerFromPublicKey` validation function is integrated.

----

_[Macroscope](https://app.macroscope.com) summarized 49713ca._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation of signing public keys when adding a node, enforcing exact length and format requirements.
	- Enhanced error handling with more specific revert reasons for invalid HTTP addresses and when the maximum number of nodes is reached.

- **Tests**
	- Updated and expanded node addition tests to use fixed, realistic Ethereum addresses and public keys.
	- Added comprehensive test coverage for multiple invalid signing public key scenarios.
	- Simplified and clarified test setup in related contracts by using predefined signer addresses and keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->