### PR TITLE
Fix the docker image in release notes

### DIFF
--- a/.github/workflows/release-from-tag.yml
+++ b/.github/workflows/release-from-tag.yml
@@ -90,7 +90,7 @@ jobs:
           body: |
             ## Docker Image
             ```
-            ghcr.io/xmtp/xmtpd-anvil:${{ github.ref_name }}
+            ghcr.io/xmtp/contracts:${{ github.ref_name }}
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### TL;DR

Updated Docker image reference in GitHub release notes from `xmtpd-anvil` to `contracts`.

### What changed?

Changed the Docker image path in the release-from-tag.yml workflow file from `ghcr.io/xmtp/xmtpd-anvil:${{ github.ref_name }}` to `ghcr.io/xmtp/contracts:${{ github.ref_name }}`.

### How to test?

1. Create a new tag and verify that the GitHub release notes display the correct Docker image path
2. Confirm that the Docker image reference in the release notes matches `ghcr.io/xmtp/contracts:[tag-name]`

### Why make this change?

To ensure the release notes reference the correct Docker image repository name, aligning with the actual container registry path where the images are published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker image reference in release notes to display the correct image name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->