### PR TITLE
feat: NoChange() if setHttp is a noop

### DIFF
--- a/src/settlement-chain/NodeRegistry.sol
+++ b/src/settlement-chain/NodeRegistry.sol
@@ -160,16 +160,15 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     /// @inheritdoc INodeRegistry
     function setHttpAddress(uint32 nodeId_, string calldata httpAddress_) external {
         _revertIfNotNodeOwner(nodeId_);
+
         if (bytes(httpAddress_).length == 0) revert InvalidHttpAddress();
 
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
 
-        string storage currentAddress = $.nodes[nodeId_].httpAddress;
-        if (keccak256(bytes(currentAddress)) == keccak256(bytes(httpAddress_))) {
-            revert NoChange();
-        }
+        if (keccak256(bytes($.nodes[nodeId_].httpAddress)) == keccak256(bytes(httpAddress_))) revert NoChange();
 
         $.nodes[nodeId_].httpAddress = httpAddress_;
+
         emit HttpAddressUpdated(nodeId_, httpAddress_);
     }
 

--- a/test/unit/NodeRegistry.t.sol
+++ b/test/unit/NodeRegistry.t.sol
@@ -382,6 +382,17 @@ contract NodeRegistryTests is Test {
         _registry.setHttpAddress(1, "");
     }
 
+    function test_setHttpAddress_noChange() external {
+        string memory httpAddress_ = "http://example.com";
+
+        _addNode(1, _alice, address(0), false, "", httpAddress_);
+
+        vm.expectRevert(INodeRegistry.NoChange.selector);
+
+        vm.prank(_alice);
+        _registry.setHttpAddress(1, httpAddress_);
+    }
+
     function test_setHttpAddress() external {
         _addNode(1, _alice, address(0), false, "", "");
 
@@ -393,17 +404,6 @@ contract NodeRegistryTests is Test {
         _registry.setHttpAddress(1, "http://example.com");
 
         assertEq(_registry.__getNode(1).httpAddress, "http://example.com");
-    }
-
-    function test_setHttpAddress_noChange() external {
-        string memory httpAddress = "http://example.com";
-
-        _addNode(1, _alice, address(0), false, "", httpAddress);
-
-        vm.expectRevert(INodeRegistry.NoChange.selector);
-
-        vm.prank(_alice);
-        _registry.setHttpAddress(1, httpAddress);
     }
 
     /* ============ setBaseURI ============ */


### PR DESCRIPTION
### Prevent redundant HTTP address updates in NodeRegistry.setHttpAddress by adding NoChange validation check
The `setHttpAddress` function in [NodeRegistry.sol](https://github.com/xmtp/smart-contracts/pull/91/files#diff-4059215632391073d4048ae397284d2a9cc5727794ad78c69b3e14476319aafb) now validates that the new HTTP address differs from the current one before performing the update. The function compares addresses using keccak256 hash comparison and reverts with a `NoChange` error when attempting to set an identical address. A corresponding test case in [NodeRegistry.t.sol](https://github.com/xmtp/smart-contracts/pull/91/files#diff-048b25e6c47ed8a12fec70597c3601ac95ce99ed773ebceb9b13f15694a5c979) verifies this validation behavior.

#### 📍Where to Start
Start with the `setHttpAddress` function in [NodeRegistry.sol](https://github.com/xmtp/smart-contracts/pull/91/files#diff-4059215632391073d4048ae397284d2a9cc5727794ad78c69b3e14476319aafb) to review the new validation logic.

----

_[Macroscope](https://app.macroscope.com) summarized 68ba2b4._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the update process for HTTP addresses to prevent unnecessary changes when the new address matches the current one.

- **Tests**
  - Added a test to ensure that attempting to set an identical HTTP address is correctly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->