### PR TITLE
feat: `groupId` is `bytes16`

### DIFF
--- a/config/testnet-dev.json
+++ b/config/testnet-dev.json
@@ -13,7 +13,7 @@
     "feeTokenProxySalt": "FeeToken_0",
     "gatewayProxy": "0xB64D5bF62F30512Bd130C0D7c80DB7ac1e6801a3",
     "gatewayProxySalt": "Gateway_0_0",
-    "groupMessageBroadcasterImplementation": "0x98A78026c1705017015eD026b0be580B28D7f995",
+    "groupMessageBroadcasterImplementation": "0x8Cb63814244cDE3c769C9d84C12A448826d38EE0",
     "groupMessageBroadcasterProxy": "0xbDF24fD4bBaE0E3CCd42Fb6C07EC6eA347A1Ef87",
     "groupMessageBroadcasterProxySalt": "GroupMessageBroadcaster_0_0",
     "identityUpdateBroadcasterImplementation": "0xb9eb25f3CF7B8ed9BAD69da60dF279cb0aB4ccd7",

--- a/src/app-chain/GroupMessageBroadcaster.sol
+++ b/src/app-chain/GroupMessageBroadcaster.sol
@@ -22,7 +22,7 @@ contract GroupMessageBroadcaster is IGroupMessageBroadcaster, PayloadBroadcaster
     /* ============ Interactive Functions ============ */
 
     /// @inheritdoc IGroupMessageBroadcaster
-    function addMessage(bytes32 groupId_, bytes calldata message_) external {
+    function addMessage(bytes16 groupId_, bytes calldata message_) external {
         _revertIfPaused();
         _revertIfInvalidPayloadSize(message_.length);
 
@@ -33,7 +33,7 @@ contract GroupMessageBroadcaster is IGroupMessageBroadcaster, PayloadBroadcaster
 
     /// @inheritdoc IGroupMessageBroadcaster
     function bootstrapMessages(
-        bytes32[] calldata groupIds_,
+        bytes16[] calldata groupIds_,
         bytes[] calldata messages_,
         uint64[] calldata sequenceIds_
     ) external {

--- a/src/app-chain/interfaces/IGroupMessageBroadcaster.sol
+++ b/src/app-chain/interfaces/IGroupMessageBroadcaster.sol
@@ -16,7 +16,7 @@ interface IGroupMessageBroadcaster is IPayloadBroadcaster {
      * @param  message    The message in bytes. Contains the full MLS group message payload.
      * @param  sequenceId The unique sequence ID of the message.
      */
-    event MessageSent(bytes32 indexed groupId, bytes message, uint64 indexed sequenceId);
+    event MessageSent(bytes16 indexed groupId, bytes message, uint64 indexed sequenceId);
 
     /* ============ Custom Errors ============ */
 
@@ -34,7 +34,7 @@ interface IGroupMessageBroadcaster is IPayloadBroadcaster {
      * @param  message_ The message in bytes.
      * @dev    Ensures the payload length is within the allowed range and increments the sequence ID.
      */
-    function addMessage(bytes32 groupId_, bytes calldata message_) external;
+    function addMessage(bytes16 groupId_, bytes calldata message_) external;
 
     /**
      * @notice Bootstraps messages to satisfy a migration.
@@ -43,7 +43,7 @@ interface IGroupMessageBroadcaster is IPayloadBroadcaster {
      * @param  sequenceIds_ The sequence IDs.
      */
     function bootstrapMessages(
-        bytes32[] calldata groupIds_,
+        bytes16[] calldata groupIds_,
         bytes[] calldata messages_,
         uint64[] calldata sequenceIds_
     ) external;

--- a/test/unit/GroupMessageBroadcaster.t.sol
+++ b/test/unit/GroupMessageBroadcaster.t.sol
@@ -14,7 +14,7 @@ import { GroupMessageBroadcasterHarness } from "../utils/Harnesses.sol";
 import { Utils } from "../utils/Utils.sol";
 
 contract GroupMessageBroadcasterTests is Test {
-    bytes32 internal constant _ID = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+    bytes16 internal constant _ID = 0x1234567890abcdef1234567890abcdef;
 
     string internal constant _PAUSED_KEY = "xmtp.groupMessageBroadcaster.paused";
     string internal constant _MIGRATOR_KEY = "xmtp.groupMessageBroadcaster.migrator";
@@ -173,7 +173,7 @@ contract GroupMessageBroadcasterTests is Test {
 
         vm.expectRevert(IPayloadBroadcaster.NotPaused.selector);
 
-        _broadcaster.bootstrapMessages(new bytes32[](0), new bytes[](0), new uint64[](0));
+        _broadcaster.bootstrapMessages(new bytes16[](0), new bytes[](0), new uint64[](0));
     }
 
     function test_bootstrapMessages_notPayloadBootstrapper() external {
@@ -181,7 +181,7 @@ contract GroupMessageBroadcasterTests is Test {
 
         vm.expectRevert(IPayloadBroadcaster.NotPayloadBootstrapper.selector);
 
-        _broadcaster.bootstrapMessages(new bytes32[](0), new bytes[](0), new uint64[](0));
+        _broadcaster.bootstrapMessages(new bytes16[](0), new bytes[](0), new uint64[](0));
     }
 
     function test_bootstrapMessages_arrayLengthMismatch() external {
@@ -191,12 +191,12 @@ contract GroupMessageBroadcasterTests is Test {
         vm.expectRevert(IGroupMessageBroadcaster.ArrayLengthMismatch.selector);
 
         vm.prank(_payloadBootstrapper);
-        _broadcaster.bootstrapMessages(new bytes32[](1), new bytes[](0), new uint64[](1));
+        _broadcaster.bootstrapMessages(new bytes16[](1), new bytes[](0), new uint64[](1));
 
         vm.expectRevert(IGroupMessageBroadcaster.ArrayLengthMismatch.selector);
 
         vm.prank(_payloadBootstrapper);
-        _broadcaster.bootstrapMessages(new bytes32[](1), new bytes[](1), new uint64[](0));
+        _broadcaster.bootstrapMessages(new bytes16[](1), new bytes[](1), new uint64[](0));
     }
 
     function test_bootstrapMessages_emptyArray() external {
@@ -206,7 +206,7 @@ contract GroupMessageBroadcasterTests is Test {
         vm.expectRevert(IGroupMessageBroadcaster.EmptyArray.selector);
 
         vm.prank(_payloadBootstrapper);
-        _broadcaster.bootstrapMessages(new bytes32[](0), new bytes[](0), new uint64[](0));
+        _broadcaster.bootstrapMessages(new bytes16[](0), new bytes[](0), new uint64[](0));
     }
 
     function test_bootstrapMessages() external {
@@ -214,9 +214,9 @@ contract GroupMessageBroadcasterTests is Test {
         _broadcaster.__setPayloadBootstrapper(_payloadBootstrapper);
         _broadcaster.__setSequenceId(5);
 
-        bytes32[] memory groupIds_ = new bytes32[](2);
-        groupIds_[0] = bytes32(uint256(1));
-        groupIds_[1] = bytes32(uint256(2));
+        bytes16[] memory groupIds_ = new bytes16[](2);
+        groupIds_[0] = bytes16(uint128(1));
+        groupIds_[1] = bytes16(uint128(2));
 
         bytes[] memory messages_ = new bytes[](2);
         messages_[0] = Utils.generatePayload(1);


### PR DESCRIPTION
_Macroscope is automatically generating a summary of this pull request..._

<picture>
<source media="(prefers-color-scheme: dark)" srcset="https://prasso.ai/static/prassoai-pr-loader-small-dark-no-text.gif">
<img src="https://prasso.ai/static/prassoai-pr-loader-small-light-no-text.gif" alt="_Macroscope is automatically generating a summary of this pull request..._">
</picture>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated system to use shorter group IDs, reducing their size from 32 bytes to 16 bytes for group messaging operations.

* **Chores**
  * Updated configuration to use a new contract address for group message broadcasting on the test network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->