### PR TITLE
fix: Remove indexing of `ParameterSet` arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@xmtp/smart-contracts",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "XMTP Smart Contracts",
     "author": "Ephemera Engineering Team <eng@ephemerahq.com>",
     "repository": {

--- a/src/abstract/ParameterRegistry.sol
+++ b/src/abstract/ParameterRegistry.sol
@@ -135,7 +135,7 @@ abstract contract ParameterRegistry is IParameterRegistry, Migratable, Initializ
     /* ============ Internal Interactive Functions ============ */
 
     function _setParameter(ParameterRegistryStorage storage $, string memory key_, bytes32 value_) internal {
-        emit ParameterSet(key_, $.parameters[key_] = value_);
+        emit ParameterSet(key_, key_, $.parameters[key_] = value_);
     }
 
     /* ============ Internal View/Pure Functions ============ */

--- a/src/abstract/interfaces/IParameterRegistry.sol
+++ b/src/abstract/interfaces/IParameterRegistry.sol
@@ -19,7 +19,7 @@ interface IParameterRegistry is IMigratable, IParameterKeysErrors, IRegistryPara
      * @param  value The value of the parameter (which can represent any value type).
      * @dev    Values that are not value types (e.g. bytes, arrays, structs, etc.) must be the hash of their contents.
      */
-    event ParameterSet(string indexed key, bytes32 indexed value);
+    event ParameterSet(string key, bytes32 value);
 
     /* ============ Custom Errors ============ */
 

--- a/src/abstract/interfaces/IParameterRegistry.sol
+++ b/src/abstract/interfaces/IParameterRegistry.sol
@@ -18,6 +18,7 @@ interface IParameterRegistry is IMigratable, IParameterKeysErrors, IRegistryPara
      * @param  key   The key of the parameter (which is generally a human-readable string, for clarity).
      * @param  value The value of the parameter (which can represent any value type).
      * @dev    Values that are not value types (e.g. bytes, arrays, structs, etc.) must be the hash of their contents.
+     * @dev    The key is intentionally non-indexed so it remains visible/decodable in explorers and subgraphs.
      */
     event ParameterSet(string key, bytes32 value);
 

--- a/src/abstract/interfaces/IParameterRegistry.sol
+++ b/src/abstract/interfaces/IParameterRegistry.sol
@@ -15,12 +15,14 @@ interface IParameterRegistry is IMigratable, IParameterKeysErrors, IRegistryPara
 
     /**
      * @notice Emitted when a parameter is set.
-     * @param  key   The key of the parameter (which is generally a human-readable string, for clarity).
-     * @param  value The value of the parameter (which can represent any value type).
+     * @param  keyHash The hash of the key of the parameter.
+     * @param  key     The key of the parameter (which is generally a human-readable string, for clarity).
+     * @param  value   The value of the parameter (which can represent any value type).
      * @dev    Values that are not value types (e.g. bytes, arrays, structs, etc.) must be the hash of their contents.
-     * @dev    The key is intentionally non-indexed so it remains visible/decodable in explorers and subgraphs.
+     * @dev    When passing the key as the first argument when emitting this event, it is automatically hashed since
+     *         reference types are not indexable, and the hash is thus the indexable value.
      */
-    event ParameterSet(string key, bytes32 value);
+    event ParameterSet(string indexed keyHash, string key, bytes32 value);
 
     /* ============ Custom Errors ============ */
 

--- a/test/unit/ParameterRegistry.t.sol
+++ b/test/unit/ParameterRegistry.t.sol
@@ -116,10 +116,10 @@ contract ParameterRegistryTests is Test {
         values_[1] = bytes32(uint256(2020202));
 
         vm.expectEmit(address(_registry));
-        emit IParameterRegistry.ParameterSet(keys_[0], values_[0]);
+        emit IParameterRegistry.ParameterSet(keys_[0], keys_[0], values_[0]);
 
         vm.expectEmit(address(_registry));
-        emit IParameterRegistry.ParameterSet(keys_[1], values_[1]);
+        emit IParameterRegistry.ParameterSet(keys_[1], keys_[1], values_[1]);
 
         vm.prank(_admin1);
         _registry.set(keys_, values_);
@@ -138,7 +138,7 @@ contract ParameterRegistryTests is Test {
 
     function test_set_one() external {
         vm.expectEmit(address(_registry));
-        emit IParameterRegistry.ParameterSet("this.is.a.parameter", bytes32(uint256(1010101)));
+        emit IParameterRegistry.ParameterSet("this.is.a.parameter", "this.is.a.parameter", bytes32(uint256(1010101)));
 
         vm.prank(_admin1);
         _registry.set("this.is.a.parameter", bytes32(uint256(1010101)));


### PR DESCRIPTION
Indexed strings are hashed and thus unreadable/un-decodable in explorers and via subgraph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Parameter update events now include a hashed key for indexing plus the plain key and value in the event payload. The plain key and value are no longer indexed, making them readable/decodable in explorers and subgraphs but altering how listeners and log filters match events.

* **Chores**
  * Bumped package version to 0.5.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->