### PR TITLE
Expand docs with ParameterRegistry keys

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -12,7 +12,7 @@ For newcomers to XMTP, we recommend starting with the **[System Architecture](./
 
 - **[System architecture](./architecture.md)**: _Start here_ - Complete system overview, chain architecture, and key concepts
 - **[Contracts](./contracts.md)**: Detailed smart contract specifications and interactions
-- **[Parameter flow](./parameter-flow.md)**: Cross-chain parameter synchronization mechanism
+- **[Parameter Registry](./parameter-registry.md)** - Cross-chain parameter synchronization mechanism
 
 ### Actor-specific guides
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,6 +1,6 @@
 # XMTP network system architecture
 
-> Last edited: 09/15/2025
+> Last edited: 09/17/2025
 
 - [XMTP network system architecture](#xmtp-network-system-architecture)
   - [System overview](#system-overview)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -18,7 +18,7 @@
       - [xmtpd service components](#xmtpd-service-components)
       - [Onboarding process](#onboarding-process)
     - [Administrators](#administrators)
-      - [Parameter flow](#parameter-flow)
+      - [Parameter Registry](#parameter-registry)
   - [Economic model](#economic-model)
     - [Fee structure](#fee-structure)
     - [Settlement process](#settlement-process)
@@ -202,8 +202,6 @@ End users are the ultimate consumers of XMTP messaging services, typically acces
 
 Administrators manage system governance, parameters, and network operations through multi-signature wallets and eventual governance mechanisms.
 
-The [Parameter Registry](./parameter-flow.md) plays a major role on this task.
-
 **Responsibilities**:
 
 - **Parameter management**: Update system parameters via SettlementChainParameterRegistry
@@ -211,7 +209,9 @@ The [Parameter Registry](./parameter-flow.md) plays a major role on this task.
 - **Upgrade coordination**: Manage contract upgrades and migrations
 - **Economic policy**: Set fee rates, distribution parameters, and protocol policies
 
-#### Parameter flow
+#### Parameter Registry
+
+The [Parameter Registry](./parameter-registry.md) is the centralized on-chain configuration repository.
 
 ```mermaid
 sequenceDiagram

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,4 +1,11 @@
-# XMTP smart contracts - communication dependency diagram
+# XMTP network contracts - communication dependency diagram
+
+- [XMTP network contracts - communication dependency diagram](#xmtp-network-contracts---communication-dependency-diagram)
+  - [Contract communication diagram](#contract-communication-diagram)
+  - [Key communication dependencies](#key-communication-dependencies)
+    - [XMTP Settlement Chain contracts](#xmtp-settlement-chain-contracts)
+    - [XMTP App Chain contracts](#xmtp-app-chain-contracts)
+  - [Primary communication flows](#primary-communication-flows)
 
 This diagram illustrates the communication dependencies between contracts in the XMTP smart contracts ecosystem, focusing exclusively on which contracts call functions on other contracts (not inheritance).
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -1,4 +1,11 @@
-# Deployment
+# XMTP network contracts - deployment
+
+- [XMTP network contracts - deployment](#xmtp-network-contracts---deployment)
+  - [Base contracts](#base-contracts)
+    - [Constraints](#constraints)
+    - [Deploy base contracts](#deploy-base-contracts)
+  - [Environment contracts](#environment-contracts)
+    - [Deploy environment contracts](#deploy-environment-contracts)
 
 The project includes deploy and upgrade scripts.
 
@@ -16,7 +23,7 @@ The project includes deploy and upgrade scripts.
 
 Because of the above, for each XMTP Settlement Chain, regardless of environment, a set of base contracts must be deployed only once. This deployment includes the `Factory`, `SettlementChainParameterRegistry`, `FeeToken` (and `MockUnderlyingFeeToken` if it is a testnet), and `SettlementChainGateway` for the XMTP Settlement Chain, and the `Factory`, `AppChainParameterRegistry`, and `AppChainGateway` for the XMTP App Chain. These are called the "base contracts" because they are the base contracts that are required before any environment-specific contracts are deployed.
 
-### Deployment
+### Deploy base contracts
 
 These base contracts are deployed via:
 
@@ -35,7 +42,7 @@ They are verified via:
 
 This deployment includes the `PayerRegistry`, `RateRegistry`, `NodeRegistry`, `PayerReportManager`, `DistributionManager`, and `DepositSplitter` for the XMTP Settlement Chain, and the `GroupMessageBroadcaster`, `IdentityUpdateBroadcaster` for the XMTP App Chain.
 
-### Deployment
+### Deploy environment contracts
 
 These are deployed via:
 
@@ -64,7 +71,7 @@ The parameters are applied at each settlement chain contract via:
 ./dev/update-starting-parameters <ENVIRONMENT> settlement-chain
 ```
 
-Some parameters are bridged to the app chainvia:
+Some parameters are bridged to the app chain via:
 
 ```shell
 ./dev/bridge-starting-parameters <ENVIRONMENT>

--- a/doc/node-operators.md
+++ b/doc/node-operators.md
@@ -1,5 +1,16 @@
 # XMTP node operators
 
+- [XMTP node operators](#xmtp-node-operators)
+  - [Node identification system](#node-identification-system)
+  - [Canonical network](#canonical-network)
+  - [Node onboarding process](#node-onboarding-process)
+  - [Canonical network management](#canonical-network-management)
+  - [Node synchronization process](#node-synchronization-process)
+  - [Key features](#key-features)
+    - [Node authentication](#node-authentication)
+    - [Network consensus](#network-consensus)
+    - [Operational management](#operational-management)
+
 Node operators are managed through the [Node Registry](../src/settlement-chain/NodeRegistry.sol) contract, where they are registered as NFTs representing their node ownership and operational rights.
 
 The node operator configures the `xmtpd` service to use the wallet private key holding the NFT, authenticating the node during startup and network operations.

--- a/doc/parameter-registry.md
+++ b/doc/parameter-registry.md
@@ -1,6 +1,103 @@
-# XMTP parameter flow - sequence diagrams
+# XMTP Parameter Registry
 
 This document illustrates the complete process of setting a parameter in the XMTP Settlement Chain parameter registry and its journey to being fetched by a contract on an XMTP App Chain.
+
+## Available Configuration
+
+The XMTP protocol uses a comprehensive parameter system to manage configuration across all contracts. Parameters are organized by contract and functionality, using a hierarchical key structure. All parameter keys follow the pattern `xmtp.{contract}.{parameter}`.
+
+### Settlement Chain Parameters
+
+#### Settlement Chain Parameter Registry
+
+- **`xmtp.settlementChainParameterRegistry.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.settlementChainParameterRegistry.isAdmin.{address}`**: Admin status for specific addresses. Note: addresses are always lowercase.
+
+#### Fee Token
+
+- **`xmtp.feeToken.migrator`**: Address of the migrator contract for upgrades
+
+#### Node Registry
+
+- **`xmtp.nodeRegistry.admin`**: Administrator address for node management
+- **`xmtp.nodeRegistry.maxCanonicalNodes`**: Maximum number of canonical nodes allowed
+- **`xmtp.nodeRegistry.migrator`**: Address of the migrator contract for upgrades
+
+#### Payer Registry
+
+- **`xmtp.payerRegistry.settler`**: Address authorized to settle usage fees
+- **`xmtp.payerRegistry.feeDistributor`**: Address of the fee distribution contract
+- **`xmtp.payerRegistry.minimumDeposit`**: Minimum deposit amount required for payers
+- **`xmtp.payerRegistry.withdrawLockPeriod`**: Time lock period for withdrawals (in seconds)
+- **`xmtp.payerRegistry.paused`**: Pause status for payer operations
+- **`xmtp.payerRegistry.migrator`**: Address of the migrator contract for upgrades
+
+#### Payer Report Manager
+
+- **`xmtp.payerReportManager.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.payerReportManager.protocolFeeRate`**: Protocol fee rate in basis points (0-10000)
+
+#### Distribution Manager
+
+- **`xmtp.distributionManager.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.distributionManager.paused`**: Pause status for distribution operations
+- **`xmtp.distributionManager.protocolFeesRecipient`**: Address receiving protocol fees
+
+#### Rate Registry
+
+- **`xmtp.rateRegistry.messageFee`**: Fee per message in protocol units
+- **`xmtp.rateRegistry.storageFee`**: Fee per storage unit in protocol units
+- **`xmtp.rateRegistry.congestionFee`**: Additional fee during network congestion
+- **`xmtp.rateRegistry.targetRatePerMinute`**: Target processing rate per minute
+- **`xmtp.rateRegistry.migrator`**: Address of the migrator contract for upgrades
+
+#### Settlement Chain Gateway
+
+- **`xmtp.settlementChainGateway.inbox.{chainId}`**: Inbox address for specific chain ID
+- **`xmtp.settlementChainGateway.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.settlementChainGateway.paused`**: Pause status for gateway operations
+
+#### Factory (Any Chain)
+
+- **`xmtp.factory.paused`**: Pause status for contract deployment
+- **`xmtp.factory.migrator`**: Address of the migrator contract for upgrades
+
+### App Chain Parameters
+
+#### App Chain Parameter Registry
+
+- **`xmtp.appChainParameterRegistry.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.appChainParameterRegistry.isAdmin.{address}`**: Admin status for specific addresses
+
+#### App Chain Gateway
+
+- **`xmtp.appChainGateway.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.appChainGateway.paused`**: Pause status for gateway operations
+
+#### Group Message Broadcaster
+
+- **`xmtp.groupMessageBroadcaster.minPayloadSize`**: Minimum allowed message payload size
+- **`xmtp.groupMessageBroadcaster.maxPayloadSize`**: Maximum allowed message payload size
+- **`xmtp.groupMessageBroadcaster.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.groupMessageBroadcaster.paused`**: Pause status for message broadcasting
+- **`xmtp.groupMessageBroadcaster.payloadBootstrapper`**: Address authorized to bootstrap messages
+
+#### Identity Update Broadcaster
+
+- **`xmtp.identityUpdateBroadcaster.minPayloadSize`**: Minimum allowed identity update payload size
+- **`xmtp.identityUpdateBroadcaster.maxPayloadSize`**: Maximum allowed identity update payload size
+- **`xmtp.identityUpdateBroadcaster.migrator`**: Address of the migrator contract for upgrades
+- **`xmtp.identityUpdateBroadcaster.paused`**: Pause status for identity update broadcasting
+- **`xmtp.identityUpdateBroadcaster.payloadBootstrapper`**: Address authorized to bootstrap identity updates
+
+### Parameter Types and Validation
+
+Parameters are stored as `bytes32` values but represent different data types:
+
+- **Addresses**: Stored as `uint160` cast to `bytes32`
+- **Booleans**: `0` for false, `1` for true
+- **Integers**: Various unsigned integer types (`uint8`, `uint16`, `uint32`, `uint64`, `uint96`)
+- **Strings**: Hash of the string content for non-value types
 
 ## PlantUML version
 
@@ -132,12 +229,12 @@ sequenceDiagram
 
 1. **Admin sets parameter on the XMTP Settlement Chain**:
 
-    - Admin/governance calls `set(key, value)` on Settlement Parameter Registry
-    - The registry stores the parameter and emits an event
+   - Admin/governance calls `set(key, value)` on Settlement Parameter Registry
+   - The registry stores the parameter and emits an event
 
 2. **User initiates parameter bridging**:
-    - User/system calls `sendParametersAsRetryableTickets(keys)` on Settlement Chain Gateway
-    - This begins the cross-chain bridging process
+   - User/system calls `sendParametersAsRetryableTickets(keys)` on Settlement Chain Gateway
+   - This begins the cross-chain bridging process
 
 3-6. **Settlement Chain Gateway prepares and sends parameters**:
 

--- a/doc/parameter-registry.md
+++ b/doc/parameter-registry.md
@@ -1,4 +1,26 @@
-# XMTP Parameter Registry
+# XMTP network contracts - Parameter registry
+
+- [XMTP network contracts - Parameter registry](#xmtp-network-contracts---parameter-registry)
+  - [Available Configuration](#available-configuration)
+    - [Settlement Chain Parameters](#settlement-chain-parameters)
+      - [Settlement Chain Parameter Registry](#settlement-chain-parameter-registry)
+      - [Fee Token](#fee-token)
+      - [Node Registry](#node-registry)
+      - [Payer Registry](#payer-registry)
+      - [Payer Report Manager](#payer-report-manager)
+      - [Distribution Manager](#distribution-manager)
+      - [Rate Registry](#rate-registry)
+      - [Settlement Chain Gateway](#settlement-chain-gateway)
+      - [Factory (Any Chain)](#factory-any-chain)
+    - [App Chain Parameters](#app-chain-parameters)
+      - [App Chain Parameter Registry](#app-chain-parameter-registry)
+      - [App Chain Gateway](#app-chain-gateway)
+      - [Group Message Broadcaster](#group-message-broadcaster)
+      - [Identity Update Broadcaster](#identity-update-broadcaster)
+    - [Parameter Types and Validation](#parameter-types-and-validation)
+  - [PlantUML version](#plantuml-version)
+  - [Mermaid version](#mermaid-version)
+  - [Explanation of parameter flow steps](#explanation-of-parameter-flow-steps)
 
 This document illustrates the complete process of setting a parameter in the XMTP Settlement Chain parameter registry and its journey to being fetched by a contract on an XMTP App Chain.
 
@@ -121,7 +143,7 @@ SPR --> Admin: Emit ParameterSet event
 deactivate SPR
 
 == Cross-Chain Parameter Bridging ==
-User -> SCG: 2. call sendParametersAsRetryableTickets(keys)
+User -> SCG: 2. call sendParameters(chainIds, keys, gasLimit, maxFeePerGas, amountToSend)
 activate SCG
 SCG -> SPR: 3. get(key)
 activate SPR
@@ -184,7 +206,7 @@ sequenceDiagram
 
     rect rgb(240, 240, 240)
     Note over User, ACG: Cross-Chain Parameter Bridging
-    User->>SCG: 2. call sendParametersAsRetryableTickets(keys)
+    User->>SCG: 2. call sendParameters(chainIds, keys, gasLimit, maxFeePerGas, amountToSend)
     activate SCG
     SCG->>SPR: 3. get(key)
     activate SPR
@@ -233,7 +255,7 @@ sequenceDiagram
    - The registry stores the parameter and emits an event
 
 2. **User initiates parameter bridging**:
-   - User/system calls `sendParametersAsRetryableTickets(keys)` on Settlement Chain Gateway
+   - User/system calls `sendParameters(chainIds, keys, gasLimit, maxFeePerGas, amountToSend)` on Settlement Chain Gateway
    - This begins the cross-chain bridging process
 
 3-6. **Settlement Chain Gateway prepares and sends parameters**:

--- a/doc/payer-reports.md
+++ b/doc/payer-reports.md
@@ -1,4 +1,21 @@
-# Payer reports
+# XMTP network economic model - Payer reports
+
+- [XMTP network economic model - Payer reports](#xmtp-network-economic-model---payer-reports)
+  - [PayerReport structure](#payerreport-structure)
+    - [Field descriptions](#field-descriptions)
+  - [EIP-712 signature hash](#eip-712-signature-hash)
+  - [Merkle tree structure](#merkle-tree-structure)
+  - [Report lifecycle](#report-lifecycle)
+    - [1. Report generation (offchain)](#1-report-generation-offchain)
+    - [2. Attestation and signing](#2-attestation-and-signing)
+    - [3. Report submission](#3-report-submission)
+    - [4. Settlement process](#4-settlement-process)
+  - [Key features](#key-features)
+    - [Sequential processing](#sequential-processing)
+    - [Consensus mechanism](#consensus-mechanism)
+    - [Economic integration](#economic-integration)
+    - [Partial settlement support](#partial-settlement-support)
+  - [Error handling](#error-handling)
 
 As described in the [architecture](./architecture.md) document, the MLS standard defines multiple message types. In the XMTP network, two of those types are directly published to the blockchain, and payers through the `Gateway` service pay directly for the gas used to publish them.
 

--- a/doc/payers.md
+++ b/doc/payers.md
@@ -1,4 +1,11 @@
-# Payers
+# XMTP network economic model - Payers
+
+- [XMTP network economic model - Payers](#xmtp-network-economic-model---payers)
+  - [Funding methods](#funding-methods)
+    - [Manual funding process](#manual-funding-process)
+    - [Simplified funding with DepositSplitter](#simplified-funding-with-depositsplitter)
+    - [XMTP Funding Portal integration](#xmtp-funding-portal-integration)
+  - [DepositSplitter workflow](#depositsplitter-workflow)
 
 Payers are entities (typically app developers, agents, or service providers) who need to fund their accounts to pay for XMTP network services such as message broadcasting and identity updates. XMTP provides multiple funding mechanisms to accommodate different user preferences and technical capabilities.
 

--- a/doc/proxies.md
+++ b/doc/proxies.md
@@ -1,4 +1,9 @@
-# Proxy, factory, and migration patterns
+# XMTP network contracts - Proxy, factory, and migration patterns
+
+- [XMTP network contracts - Proxy, factory, and migration patterns](#xmtp-network-contracts---proxy-factory-and-migration-patterns)
+  - [Proxy pattern](#proxy-pattern)
+  - [Factory pattern](#factory-pattern)
+  - [Migration pattern](#migration-pattern)
 
 ## Proxy pattern
 
@@ -106,7 +111,7 @@ Note that it is possible for the new implementation to define entirely new migra
 
 The additional benefits of this mechanism are that individual proxies or implementations are not burdened (in both code size and complexity) by having to define the specific migration logic based on the version of the implementation that is being migrated from. The specific migration code is completely decoupled and compartmentalized in a deployed `Migrator` contract (which can be voted on by governance), which can perform additional checks (i.e., starting implementation slot value) and validations.
 
-A sample `Migrator` contract is provided in the [Migrator.sol](../src/any-chain/Migrator.sol) file, which is deployed by the `Factory` contract via the `deployImplementation` function, where the bytecode is the creation code of the `Migrator` contract with the `fromImplementation` and `toImplementation` as the constructor arguments. 
+A sample `Migrator` contract is provided in the [Migrator.sol](../src/any-chain/Migrator.sol) file, which is deployed by the `Factory` contract via the `deployImplementation` function, where the bytecode is the creation code of the `Migrator` contract with the `fromImplementation` and `toImplementation` as the constructor arguments.
 
 This `Migrator` contract is then used to migrate a proxy whose value at the implementation slot equals `fromImplementation`, and sets the value at the implementation slot to `toImplementation`.
 


### PR DESCRIPTION
### Expand documentation with Parameter Registry keys and replace Parameter flow references across docs
Update documentation to consolidate parameter content under a new Parameter Registry doc and refresh tables of contents across related files. • Rename links and references from Parameter flow to Parameter Registry in [README.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-a0842ea73f3a116eff7958fbf833dd2280c366c0d8985aa05f8e1403e0f39273) and [architecture.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-35f100357010f37296df44ddf3990785bfeaae4a8935177f4063b4f8028bbc71), add a new subsection describing the on-chain configuration repository, and remove the old reference. • Add [parameter-registry.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-685a6d59827eee712ba4524ad72acfbf612b6a1995ac4b12424ac9f1fd79ea75) with available configuration keys, types/validation, and the full parameter flow (including diagrams), and remove [parameter-flow.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-f49650df84d049e55befb64e48fd18a4bb4fefe2366862e95c77482077458848). • Introduce or update tables of contents and headings across [contracts.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-665b5e74d016a3b9e22ab274d0cbaf09395aeb63a9d691a5eba7e1d349663776), [dependencies.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-3f2b8984fdf0aea4a02d35b54047634465410c1526da78c0b4f888248337d135), [deployment.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-5c8349f737d543dd1b743fb95bf07007781e58e77d243fab4aff5016c79a0c5d), [node-operators.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-27c75ab8e25c2856177c9acc56f39737648ec00f464218295bde1de0f704eb78), [payer-reports.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-5cd7947c17213fc22fd175a2bbf5b34dea51217b7eed22f0ccf232ace39ce7ed), [payers.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-5752cce651cde777cb8c86966984622b078a8791bda17ff4020faca15917cbaf), and [proxies.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-5b15b566227aa3cd194b6e3ab33e87b4ae5a5cc552c2a34f33cee4583b99db6b); adjust titles and minor formatting where noted.

#### 📍Where to Start
Start with the new Parameter Registry content in [parameter-registry.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-685a6d59827eee712ba4524ad72acfbf612b6a1995ac4b12424ac9f1fd79ea75), then verify link and title changes in [README.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-a0842ea73f3a116eff7958fbf833dd2280c366c0d8985aa05f8e1403e0f39273) and [architecture.md](https://github.com/xmtp/smart-contracts/pull/134/files#diff-35f100357010f37296df44ddf3990785bfeaae4a8935177f4063b4f8028bbc71).

----

_[Macroscope](https://app.macroscope.com) summarized efc0657._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced Parameter Flow with a new Parameter Registry guide (keys, types/validation, cross‑chain flow, diagrams); deleted old parameter‑flow doc.
  * Added/standardized TOCs, headers and navigation across architecture, contracts, dependencies, deployment, node‑operators, payers, payer‑reports, proxies; clarified deployment commands and updated timestamps.
  * Documentation‑only changes; no public API or functional code edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->