### PR TITLE
Include max fees in the Deposit event

### DIFF
--- a/src/settlement-chain/SettlementChainGateway.sol
+++ b/src/settlement-chain/SettlementChainGateway.sol
@@ -405,7 +405,7 @@ contract SettlementChainGateway is ISettlementChainGateway, Migratable, Initiali
         });
 
         // slither-disable-next-line reentrancy-events
-        emit Deposit(chainId_, messageNumber_, recipient_, amount_);
+        emit Deposit(chainId_, messageNumber_, recipient_, _convertFromWei(appChainAmount_ - maxTotalCosts_));
     }
 
     /// @dev Pull the underlying fee tokens from the caller, and convert them to fee tokens.
@@ -604,6 +604,10 @@ contract SettlementChainGateway is ISettlementChainGateway, Migratable, Initiali
 
     function _convertToWei(uint256 value_) internal view returns (uint256 wei_) {
         return value_ * _scale;
+    }
+
+    function _convertFromWei(uint256 value_) internal view returns (uint256 newValue_) {
+        return value_ / _scale;
     }
 
     /**

--- a/src/settlement-chain/SettlementChainGateway.sol
+++ b/src/settlement-chain/SettlementChainGateway.sol
@@ -405,7 +405,7 @@ contract SettlementChainGateway is ISettlementChainGateway, Migratable, Initiali
         });
 
         // slither-disable-next-line reentrancy-events
-        emit Deposit(chainId_, messageNumber_, recipient_, _convertFromWei(appChainAmount_ - maxTotalCosts_));
+        emit Deposit(chainId_, messageNumber_, recipient_, amount_, _convertFromWei(maxTotalCosts_));
     }
 
     /// @dev Pull the underlying fee tokens from the caller, and convert them to fee tokens.

--- a/src/settlement-chain/SettlementChainGateway.sol
+++ b/src/settlement-chain/SettlementChainGateway.sol
@@ -607,7 +607,11 @@ contract SettlementChainGateway is ISettlementChainGateway, Migratable, Initiali
     }
 
     function _convertFromWei(uint256 value_) internal view returns (uint256 newValue_) {
-        return value_ / _scale;
+        if (_scale == 1 || value_ == 0) return value_;
+
+        unchecked {
+            return ((value_ - 1) / _scale) + 1;
+        }
     }
 
     /**

--- a/src/settlement-chain/interfaces/ISettlementChainGateway.sol
+++ b/src/settlement-chain/interfaces/ISettlementChainGateway.sol
@@ -20,7 +20,13 @@ interface ISettlementChainGateway is IMigratable, IRegistryParametersErrors {
      * @param  amount        The amount of tokens sent.
      * @param  maxFees       The maximum fees that will be consumed for the deposit.
      */
-    event Deposit(uint256 indexed chainId, uint256 indexed messageNumber, address indexed recipient, uint256 amount, uint256 maxFees);
+    event Deposit(
+        uint256 indexed chainId,
+        uint256 indexed messageNumber,
+        address indexed recipient,
+        uint256 amount,
+        uint256 maxFees
+    );
 
     /**
      * @notice Emitted when parameters have been sent to the app chain.

--- a/src/settlement-chain/interfaces/ISettlementChainGateway.sol
+++ b/src/settlement-chain/interfaces/ISettlementChainGateway.sol
@@ -18,8 +18,9 @@ interface ISettlementChainGateway is IMigratable, IRegistryParametersErrors {
      * @param  messageNumber The message number, unique per inbox.
      * @param  recipient     The recipient of the tokens on the app chain.
      * @param  amount        The amount of tokens sent.
+     * @param  maxFees       The maximum fees that will be consumed for the deposit.
      */
-    event Deposit(uint256 indexed chainId, uint256 indexed messageNumber, address indexed recipient, uint256 amount);
+    event Deposit(uint256 indexed chainId, uint256 indexed messageNumber, address indexed recipient, uint256 amount, uint256 maxFees);
 
     /**
      * @notice Emitted when parameters have been sent to the app chain.

--- a/test/unit/SettlementChainGateway.t.sol
+++ b/test/unit/SettlementChainGateway.t.sol
@@ -266,6 +266,7 @@ contract SettlementChainGatewayTests is Test {
 
         address appChainAlias_ = AddressAliasHelper.toAlias(address(_gateway));
         uint256 expectedCallValue_ = (amount_ * 10 ** 12) - submissionCost_ - (maxFeePerGas_ * gasLimit_);
+        uint256 expectedMaxFees_ = _gateway.__convertFromWei(submissionCost_ + (maxFeePerGas_ * gasLimit_));
 
         Utils.expectAndMockCall(
             inbox_,
@@ -285,7 +286,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_, expectedMaxFees_);
 
         vm.prank(_alice);
         _gateway.deposit(1111, _bob, amount_, gasLimit_, maxFeePerGas_);
@@ -561,6 +562,7 @@ contract SettlementChainGatewayTests is Test {
 
         address appChainAlias_ = AddressAliasHelper.toAlias(address(_gateway));
         uint256 expectedCallValue_ = (amount_ * 10 ** 12) - submissionCost_ - (maxFeePerGas_ * gasLimit_);
+        uint256 expectedMaxFees_ = _gateway.__convertFromWei(submissionCost_ + (maxFeePerGas_ * gasLimit_));
 
         Utils.expectAndMockCall(
             inbox_,
@@ -580,7 +582,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_, expectedMaxFees_);
 
         vm.prank(_alice);
         _gateway.depositWithPermit(1111, _bob, amount_, gasLimit_, maxFeePerGas_, 0, 0, 0, 0);
@@ -791,6 +793,7 @@ contract SettlementChainGatewayTests is Test {
 
         address appChainAlias_ = AddressAliasHelper.toAlias(address(_gateway));
         uint256 expectedCallValue_ = (amount_ * 10 ** 12) - submissionCost_ - (maxFeePerGas_ * gasLimit_);
+        uint256 expectedMaxFees_ = _gateway.__convertFromWei(submissionCost_ + (maxFeePerGas_ * gasLimit_));
 
         Utils.expectAndMockCall(
             inbox_,
@@ -810,7 +813,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_, expectedMaxFees_);
 
         vm.prank(_alice);
         _gateway.depositFromUnderlying(1111, _bob, amount_, gasLimit_, maxFeePerGas_);
@@ -1156,6 +1159,7 @@ contract SettlementChainGatewayTests is Test {
 
         address appChainAlias_ = AddressAliasHelper.toAlias(address(_gateway));
         uint256 expectedCallValue_ = (amount_ * 10 ** 12) - submissionCost_ - (maxFeePerGas_ * gasLimit_);
+        uint256 expectedMaxFees_ = _gateway.__convertFromWei(submissionCost_ + (maxFeePerGas_ * gasLimit_));
 
         Utils.expectAndMockCall(
             inbox_,
@@ -1175,7 +1179,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_, expectedMaxFees_);
 
         vm.prank(_alice);
         _gateway.depositFromUnderlyingWithPermit(1111, _bob, amount_, gasLimit_, maxFeePerGas_, 0, 0, 0, 0);

--- a/test/unit/SettlementChainGateway.t.sol
+++ b/test/unit/SettlementChainGateway.t.sol
@@ -285,7 +285,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_);
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
 
         vm.prank(_alice);
         _gateway.deposit(1111, _bob, amount_, gasLimit_, maxFeePerGas_);
@@ -580,7 +580,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_);
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
 
         vm.prank(_alice);
         _gateway.depositWithPermit(1111, _bob, amount_, gasLimit_, maxFeePerGas_, 0, 0, 0, 0);
@@ -810,7 +810,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_);
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
 
         vm.prank(_alice);
         _gateway.depositFromUnderlying(1111, _bob, amount_, gasLimit_, maxFeePerGas_);
@@ -1175,7 +1175,7 @@ contract SettlementChainGatewayTests is Test {
         );
 
         vm.expectEmit(address(_gateway));
-        emit ISettlementChainGateway.Deposit(1111, 11, _bob, amount_);
+        emit ISettlementChainGateway.Deposit(1111, 11, _bob, _gateway.__convertFromWei(expectedCallValue_));
 
         vm.prank(_alice);
         _gateway.depositFromUnderlyingWithPermit(1111, _bob, amount_, gasLimit_, maxFeePerGas_, 0, 0, 0, 0);

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -371,6 +371,10 @@ contract SettlementChainGatewayHarness is SettlementChainGateway {
     function __convertToWei(uint256 v) external view returns (uint256) {
         return _convertToWei(v);
     }
+
+    function __convertFromWei(uint256 value_) external view returns (uint256) {
+        return _convertFromWei(value_);
+    }
 }
 
 contract AppChainGatewayHarness is AppChainGateway {


### PR DESCRIPTION
Closes https://github.com/xmtp/smart-contracts/issues/139

This amount reflects the minimum value the user will get on L3 after subtracting bridging costs. Any excess is refunded to the L3 msg.sender alias.

This way we avoid emitting events carrying a value higher than the final amount deposited, which could lead to confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deposit event now emits an additional maxFees value (reported in token-decimal units).

* **Bug Fixes**
  * Emitted deposit amounts and fees standardized to token-decimal units for clearer, human-readable logs.

* **Tests**
  * Updated event assertions to expect the new maxFees field.
  * Added a test harness helper to validate conversions from wei.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->