### PR TITLE
Extend UsageSettled

### DIFF
--- a/doc/payer-reports.md
+++ b/doc/payer-reports.md
@@ -184,7 +184,7 @@ sequenceDiagram
     PRM->>PRM: Update offset for next settlement batch
 
     Note over PRM: Fee Settlement
-    PRM->>PR: settleUsage(payerFees)
+    PRM->>PR: settleUsage(payerReportId, payerFees)
     activate PR
     PR->>PR: Deduct fees from payer balances
     PR->>DM: Transfer fees to DistributionManager

--- a/src/settlement-chain/PayerRegistry.sol
+++ b/src/settlement-chain/PayerRegistry.sol
@@ -203,6 +203,7 @@ contract PayerRegistry is IPayerRegistry, Migratable, Initializable {
 
     /// @inheritdoc IPayerRegistry
     function settleUsage(
+        bytes32 payerReportId_,
         PayerFee[] calldata payerFees_
     ) external onlySettler whenNotPaused returns (uint96 feesSettled_) {
         PayerRegistryStorage storage $ = _getPayerRegistryStorage();
@@ -213,7 +214,7 @@ contract PayerRegistry is IPayerRegistry, Migratable, Initializable {
             address payer_ = payerFees_[index_].payer;
             uint96 fee_ = payerFees_[index_].fee;
 
-            emit UsageSettled(payer_, fee_);
+            emit UsageSettled(payerReportId_, payer_, fee_);
 
             feesSettled_ += fee_;
             totalDeposits_ -= _toInt104(fee_);

--- a/src/settlement-chain/PayerReportManager.sol
+++ b/src/settlement-chain/PayerReportManager.sol
@@ -187,10 +187,19 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
 
         payerReport_.isSettled = leafCount_ == payerReport_.offset;
 
+        bytes32 digest_ = _getPayerReportDigest(
+                originatorNodeId_,
+                payerReport_.startSequenceId,
+                payerReport_.endSequenceId,
+                payerReport_.endMinuteSinceEpoch,
+                payerReport_.payersMerkleRoot,
+                payerReport_.nodeIds
+        );
+
         // Low level call which handles passing the `payerFees_` arrays as a bytes array that will be automatically
         // decoded as the required structs by the payer registry's `settleUsage` function.
         (bool success_, bytes memory returnData_) = payerRegistry.call(
-            abi.encodeWithSelector(IPayerRegistryLike.settleUsage.selector, payerFees_)
+            abi.encodeWithSelector(IPayerRegistryLike.settleUsage.selector, digest_, payerFees_)
         );
 
         if (!success_) revert SettleUsageFailed(returnData_);
@@ -321,7 +330,7 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
         uint64 endSequenceId_,
         uint32 endMinuteSinceEpoch_,
         bytes32 payersMerkleRoot_,
-        uint32[] calldata nodeIds_
+        uint32[] memory nodeIds_
     ) internal view returns (bytes32 digest_) {
         return
             _getDigest(

--- a/src/settlement-chain/PayerReportManager.sol
+++ b/src/settlement-chain/PayerReportManager.sol
@@ -188,12 +188,12 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
         payerReport_.isSettled = leafCount_ == payerReport_.offset;
 
         bytes32 digest_ = _getPayerReportDigest(
-                originatorNodeId_,
-                payerReport_.startSequenceId,
-                payerReport_.endSequenceId,
-                payerReport_.endMinuteSinceEpoch,
-                payerReport_.payersMerkleRoot,
-                payerReport_.nodeIds
+            originatorNodeId_,
+            payerReport_.startSequenceId,
+            payerReport_.endSequenceId,
+            payerReport_.endMinuteSinceEpoch,
+            payerReport_.payersMerkleRoot,
+            payerReport_.nodeIds
         );
 
         // Low level call which handles passing the `payerFees_` arrays as a bytes array that will be automatically

--- a/src/settlement-chain/interfaces/External.sol
+++ b/src/settlement-chain/interfaces/External.sol
@@ -119,7 +119,7 @@ interface IPayerRegistryLike {
 
     function deposit(address payer_, uint96 amount_) external;
 
-    function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
+    function settleUsage(bytes32 payerReportId_, PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
 
     function sendExcessToFeeDistributor() external returns (uint96 excess_);
 }

--- a/src/settlement-chain/interfaces/IPayerRegistry.sol
+++ b/src/settlement-chain/interfaces/IPayerRegistry.sol
@@ -92,10 +92,11 @@ interface IPayerRegistry is IMigratable, IRegistryParametersErrors {
 
     /**
      * @notice Emitted when a payer's usage is settled.
+     * @param  payerReportId The ID of the payer report triggering the settlement.
      * @param  payer  The address of the payer.
      * @param  amount The amount of fee tokens settled (the fee deducted from their balance).
      */
-    event UsageSettled(address indexed payer, uint96 amount);
+    event UsageSettled(bytes32 indexed payerReportId, address indexed payer, uint96 amount);
 
     /**
      * @notice Emitted when excess fee tokens are transferred to the fee distributor.
@@ -266,10 +267,11 @@ interface IPayerRegistry is IMigratable, IRegistryParametersErrors {
 
     /**
      * @notice Settles the usage fees for a list of payers.
+     * @param  payerReportId_ The ID of the payer report triggering the settlement.
      * @param  payerFees_   An array of structs containing the payer and the fee to settle.
      * @return feesSettled_ The total amount of fees settled.
      */
-    function settleUsage(PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
+    function settleUsage(bytes32 payerReportId_, PayerFee[] calldata payerFees_) external returns (uint96 feesSettled_);
 
     /**
      * @notice Sends the excess tokens in the contract to the fee distributor.

--- a/test/unit/PayerRegistry.t.sol
+++ b/test/unit/PayerRegistry.t.sol
@@ -865,7 +865,7 @@ contract PayerRegistryTests is Test {
 
         vm.expectRevert(IPayerRegistry.NotSettler.selector);
         vm.prank(_unauthorized);
-        _registry.settleUsage(new IPayerRegistry.PayerFee[](0));
+        _registry.settleUsage(bytes32(0), new IPayerRegistry.PayerFee[](0));
     }
 
     function test_settleUsage_paused() external {
@@ -875,7 +875,7 @@ contract PayerRegistryTests is Test {
         vm.expectRevert(IPayerRegistry.Paused.selector);
 
         vm.prank(_settler);
-        _registry.settleUsage(new IPayerRegistry.PayerFee[](0));
+        _registry.settleUsage(bytes32(0), new IPayerRegistry.PayerFee[](0));
     }
 
     function test_settleUsage() external {
@@ -883,6 +883,8 @@ contract PayerRegistryTests is Test {
         payerFees_[0] = IPayerRegistry.PayerFee({ payer: _alice, fee: 10e6 });
         payerFees_[1] = IPayerRegistry.PayerFee({ payer: _bob, fee: 20e6 });
         payerFees_[2] = IPayerRegistry.PayerFee({ payer: _charlie, fee: 30e6 });
+
+        bytes32 payerReportId_ = keccak256("payerReportId");
 
         _registry.__setSettler(_settler);
 
@@ -894,16 +896,16 @@ contract PayerRegistryTests is Test {
         _registry.__setTotalDebt(10e6); // Charlie's debt.
 
         vm.expectEmit(address(_registry));
-        emit IPayerRegistry.UsageSettled(_alice, 10e6);
+        emit IPayerRegistry.UsageSettled(payerReportId_, _alice, 10e6);
 
         vm.expectEmit(address(_registry));
-        emit IPayerRegistry.UsageSettled(_bob, 20e6);
+        emit IPayerRegistry.UsageSettled(payerReportId_, _bob, 20e6);
 
         vm.expectEmit(address(_registry));
-        emit IPayerRegistry.UsageSettled(_charlie, 30e6);
+        emit IPayerRegistry.UsageSettled(payerReportId_, _charlie, 30e6);
 
         vm.prank(_settler);
-        uint96 feesSettled_ = _registry.settleUsage(payerFees_);
+        uint96 feesSettled_ = _registry.settleUsage(payerReportId_, payerFees_);
 
         assertEq(feesSettled_, 10e6 + 20e6 + 30e6);
 

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -483,9 +483,11 @@ contract PayerReportManagerTests is Test {
             nodeIds_: new uint32[](0)
         });
 
+        bytes32 digest_ = _manager.__getPayerReportDigest(0, 0, 0, 0, payersMerkleRoot_, new uint32[](0));
+
         vm.mockCallRevert(
             _payerRegistry,
-            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encodeWithSignature("settleUsage(bytes32,(address,uint96)[])", digest_, payerFees_),
             "Test Failure"
         );
 
@@ -520,9 +522,11 @@ contract PayerReportManagerTests is Test {
             nodeIds_: new uint32[](0)
         });
 
+        bytes32 digest_ = _manager.__getPayerReportDigest(0, 0, 0, 0, payersMerkleRoot_, new uint32[](0));
+
         Utils.expectAndMockCall(
             _payerRegistry,
-            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encodeWithSignature("settleUsage(bytes32,(address,uint96)[])", digest_, payerFees_),
             abi.encode(uint96(600))
         );
 
@@ -562,9 +566,11 @@ contract PayerReportManagerTests is Test {
             nodeIds_: new uint32[](0)
         });
 
+        bytes32 digest_ = _manager.__getPayerReportDigest(0, 0, 0, 0, payersMerkleRoot_, new uint32[](0));
+
         Utils.expectAndMockCall(
             _payerRegistry,
-            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encodeWithSignature("settleUsage(bytes32,(address,uint96)[])", digest_, payerFees_),
             abi.encode(uint96(1_500))
         );
 
@@ -606,9 +612,11 @@ contract PayerReportManagerTests is Test {
             nodeIds_: new uint32[](0)
         });
 
+        bytes32 digest_ = _manager.__getPayerReportDigest(0, 0, 0, 0, payersMerkleRoot_, new uint32[](0));
+
         Utils.expectAndMockCall(
             _payerRegistry,
-            abi.encodeWithSignature("settleUsage((address,uint96)[])", payerFees_),
+            abi.encodeWithSignature("settleUsage(bytes32,(address,uint96)[])", digest_, payerFees_),
             abi.encode(uint96(2_100))
         );
 

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -545,7 +545,15 @@ contract PayerReportManagerHarness is PayerReportManager {
         bytes32 payersMerkleRoot_,
         uint32[] memory nodeIds_
     ) external view returns (bytes32 digest_) {
-        return _getPayerReportDigest(originatorNodeId_, startSequenceId_, endSequenceId_, endMinuteSinceEpoch_, payersMerkleRoot_, nodeIds_);
+        return
+            _getPayerReportDigest(
+                originatorNodeId_,
+                startSequenceId_,
+                endSequenceId_,
+                endMinuteSinceEpoch_,
+                payersMerkleRoot_,
+                nodeIds_
+            );
     }
 }
 

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -536,6 +536,17 @@ contract PayerReportManagerHarness is PayerReportManager {
     ) external view returns (bool isValid_) {
         return _verifySignature(digest_, nodeId_, signature_);
     }
+
+    function __getPayerReportDigest(
+        uint32 originatorNodeId_,
+        uint64 startSequenceId_,
+        uint64 endSequenceId_,
+        uint32 endMinuteSinceEpoch_,
+        bytes32 payersMerkleRoot_,
+        uint32[] memory nodeIds_
+    ) external view returns (bytes32 digest_) {
+        return _getPayerReportDigest(originatorNodeId_, startSequenceId_, endSequenceId_, endMinuteSinceEpoch_, payersMerkleRoot_, nodeIds_);
+    }
 }
 
 contract DistributionManagerHarness is DistributionManager {


### PR DESCRIPTION
Closes #141

This changes helps off-chain bookkeeping avoiding double-counting. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Settlement now includes a payer report ID/digest, linking each settlement to a specific report for improved traceability.
  - UsageSettled events now include and index the report ID alongside payer and amount for clearer auditing.
- Documentation
  - Updated payer reports documentation and sequence diagram to reflect the new report ID parameter.
- Tests
  - Updated unit tests and mocks to use the new settlement signature and event format.
  - Added a test harness method to compute and expose the payer report digest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->