### PR TITLE
Start sequence ID at 1

### DIFF
--- a/src/settlement-chain/PayerReportManager.sol
+++ b/src/settlement-chain/PayerReportManager.sol
@@ -108,7 +108,7 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
 
         payerReportIndex_ = payerReports_.length;
 
-        uint64 lastSequenceId_ = payerReportIndex_ > 0 ? payerReports_[payerReportIndex_ - 1].endSequenceId : 0;
+        uint64 lastSequenceId_ = payerReportIndex_ > 0 ? payerReports_[payerReportIndex_ - 1].endSequenceId : 1;
 
         // Enforces that the start sequence ID is the last end sequence ID.
         if (startSequenceId_ != lastSequenceId_) {

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -160,7 +160,7 @@ contract PayerReportManagerTests is Test {
 
         _manager.submit({
             originatorNodeId_: 0,
-            startSequenceId_: 0,
+            startSequenceId_: 1,
             endSequenceId_: 1,
             endMinuteSinceEpoch_: 0,
             payersMerkleRoot_: 0,
@@ -174,7 +174,7 @@ contract PayerReportManagerTests is Test {
             1
         );
 
-        bytes memory signature_ = _getPayerReportSignature(0, 0, 0, 0, 0, new uint32[](0), _signer1Pk);
+        bytes memory signature_ = _getPayerReportSignature(0, 1, 1, 0, 0, new uint32[](0), _signer1Pk);
 
         signatures_[0] = IPayerReportManager.PayerReportSignature({ nodeId: 1, signature: signature_ });
 
@@ -186,8 +186,8 @@ contract PayerReportManagerTests is Test {
 
         _manager.submit({
             originatorNodeId_: 0,
-            startSequenceId_: 0,
-            endSequenceId_: 0,
+            startSequenceId_: 1,
+            endSequenceId_: 1,
             endMinuteSinceEpoch_: 0,
             payersMerkleRoot_: 0,
             nodeIds_: new uint32[](0),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Require initial payer report submissions to start at sequence ID 1 by updating `PayerReportManager.submit` in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/148/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9)
This change updates the initialization of `lastSequenceId_` in `PayerReportManager.submit` so that the first report (no prior reports) expects a `startSequenceId_` of 1. Tests are updated to reflect the new starting sequence ID.

- Modify the ternary initialization of `lastSequenceId_` to default to 1 when no prior reports exist in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/148/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9)
- Update unit tests to use `startSequenceId_ = 1` and `endSequenceId_ = 1`, including signature arguments, in [PayerReportManager.t.sol](https://github.com/xmtp/smart-contracts/pull/148/files#diff-88d841009e835b92dfaa91cbaaca83627d59bcb7e62090ff6a6af09f7ee67bdb)

#### 📍Where to Start
Start with the `submit` function in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/148/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9), then review the corresponding test updates in [PayerReportManager.t.sol](https://github.com/xmtp/smart-contracts/pull/148/files#diff-88d841009e835b92dfaa91cbaaca83627d59bcb7e62090ff6a6af09f7ee67bdb).

----

_[Macroscope](https://app.macroscope.com) summarized b57752c._
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - First payer report must now start at sequence ID 1 (was 0), resulting in stricter validation on initial submissions and clearer error handling for invalid starting IDs.
- Tests
  - Updated unit tests to reflect the new starting sequence requirement (start/end sequence ID set to 1 in initial submit scenarios).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->