### PR TITLE
Require payer report submission to be consistent with the canonical set of nodes

### DIFF
--- a/src/settlement-chain/interfaces/IPayerReportManager.sol
+++ b/src/settlement-chain/interfaces/IPayerReportManager.sol
@@ -150,9 +150,6 @@ interface IPayerReportManager is IMigratable, IERC5267, IRegistryParametersError
     /// @notice Element at `index` does not match the canonical node id at that position.
     error NodeIdAtIndexMismatch(uint32 expectedId, uint32 actualId, uint32 index);
 
-    /// @notice Thrown when the internal state is corrupted
-    error InternalStateCorrupted();
-
     /* ============ Initialization ============ */
 
     /**

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -210,7 +210,6 @@ contract PayerReportManagerTests is Test {
         nodeIds_[2] = 3;
 
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getAllNodes()"), abi.encode(all_));
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(uint8(3)));
 
         IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
             2
@@ -265,7 +264,6 @@ contract PayerReportManagerTests is Test {
         });
 
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getAllNodes()"), abi.encode(all_));
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(uint8(3)));
 
         Utils.expectAndMockCall(
             _nodeRegistry,
@@ -331,7 +329,6 @@ contract PayerReportManagerTests is Test {
         });
 
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getAllNodes()"), abi.encode(all_));
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(uint8(3)));
 
         uint32[] memory nodeIds_ = new uint32[](3);
         nodeIds_[0] = 1;
@@ -458,7 +455,6 @@ contract PayerReportManagerTests is Test {
         });
 
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getAllNodes()"), abi.encode(all_));
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(uint8(3)));
 
         uint32[] memory nodeIds_ = new uint32[](3);
         nodeIds_[0] = 1;
@@ -593,7 +589,6 @@ contract PayerReportManagerTests is Test {
         });
 
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getAllNodes()"), abi.encode(all_));
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(uint8(3)));
 
         // Submit an incorrect canonical list (length mismatch here)
         uint32[] memory nodeIds_ = new uint32[](2);
@@ -653,7 +648,6 @@ contract PayerReportManagerTests is Test {
 
         // Mock registry calls used by _enforceNodeIdsMatchCanonicalRegistry
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getAllNodes()"), abi.encode(all_));
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("canonicalNodesCount()"), abi.encode(uint8(3)));
 
         // The submitted set must be exactly the canonical set (sorted strictly increasing)
         uint32[] memory nodeIds_ = new uint32[](3);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Require `PayerReportManager.submit` in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/162/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9) to accept strictly increasing `nodeIds_` that exactly match the canonical registry set and compute quorum as `((nodeIds_.length/2)+1)`
The submit flow in `PayerReportManager` now validates that the provided `nodeIds_` strictly match the canonical set from `INodeRegistry` before signature verification, and derives the required signature quorum from the submitted `nodeIds_` length. An internal guard enforces ordering and equality against the registry’s canonical list, reverting early on mismatches. The interface adds custom errors for these failure modes, and tests are updated to reflect the new requirements and quorum calculation.

- Insert `PayerReportManager._enforceNodeIdsMatchRegistry` before signature verification in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/162/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9) to require strictly increasing `nodeIds_` that equal the canonical registry IDs and revert with `NodeIdsDoNotMatchRegistry`, `UnorderedNodeIds`, or `InternalStateCorrupted`
- Change `PayerReportManager._verifySignatures` to compute `requiredSignatureCount_` as `uint8((nodeIds_.length / 2) + 1)` with the assumption that `nodeIds_` match the canonical set in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/162/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9)
- Add `NodeIdsDoNotMatchRegistry(uint32 expectedCount, uint32 providedCount)` and `InternalStateCorrupted()` errors to [IPayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/162/files#diff-9fb0d383a957303659dfce9466a61de006a70c84e9d00bcc77e77d2cb559dd16)
- Update unit tests in [PayerReportManager.t.sol](https://github.com/xmtp/smart-contracts/pull/162/files#diff-88d841009e835b92dfaa91cbaaca83627d59bcb7e62090ff6a6af09f7ee67bdb) to provide canonical `nodeIds_`, adjust signature payloads and quorum expectations, and add negative tests for mismatched or unordered `nodeIds_`

#### 📍Where to Start
Start with the submit path in `PayerReportManager` and review the `_enforceNodeIdsMatchRegistry` guard in [PayerReportManager.sol](https://github.com/xmtp/smart-contracts/pull/162/files#diff-6a7edafdcbfd59cce9a879b0794c842ebd8f7eb961fa871b85f25513232a82f9), then follow into `_verifySignatures` to see the quorum computation changes.



#### Changes since #162 opened

- Replaced generic node ID validation errors with specific custom errors in PayerReportManager validation [ee75e50]
- Rewrote `PayerReportManager._enforceNodeIdsMatchRegistry` method enforcement logic to eliminate dependency on `canonicalNodesCount()` and use direct iteration over `getAllNodes()` [954e91f]
- Removed `InternalStateCorrupted` error declaration from `IPayerReportManager` interface [954e91f]
- Updated test mocks in `PayerReportManagerTests` to remove `canonicalNodesCount()` method mocking [954e91f]
----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 954e91f.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submitted node ID lists must exactly match the registry’s canonical set and ordering.
  * Quorum now derives from the submitted node count.
  * New explicit errors surface node list mismatches.

* **Bug Fixes**
  * Rejects unordered/mismatched node lists, insufficient signatures, and empty roots more reliably.

* **Tests**
  * Expanded coverage for canonical vs non-canonical scenarios, ordering, quorum, and related reverts; removed redundant internal verification tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->