### PR TITLE
fix: Prevent protocol fee withdrawals if recipient is zero (XMTP-11)

### DIFF
--- a/src/settlement-chain/DistributionManager.sol
+++ b/src/settlement-chain/DistributionManager.sol
@@ -227,6 +227,8 @@ contract DistributionManager is IDistributionManager, Initializable, Migratable 
     function withdrawProtocolFees() external whenNotPaused returns (uint96 withdrawn_) {
         address recipient_ = _getDistributionManagerStorage().protocolFeesRecipient;
 
+        if (_isZero(recipient_)) revert ZeroProtocolFeeRecipient();
+
         // NOTE: No need for safe library here as the fee token is a first party contract with expected behavior.
         // slither-disable-next-line unchecked-transfer
         IERC20Like(feeToken).transfer(recipient_, withdrawn_ = _prepareProtocolFeesWithdrawal(recipient_));
@@ -235,6 +237,8 @@ contract DistributionManager is IDistributionManager, Initializable, Migratable 
     /// @inheritdoc IDistributionManager
     function withdrawProtocolFeesIntoUnderlying() external whenNotPaused returns (uint96 withdrawn_) {
         address recipient_ = _getDistributionManagerStorage().protocolFeesRecipient;
+
+        if (_isZero(recipient_)) revert ZeroProtocolFeeRecipient();
 
         // NOTE: No need for safe library here as the fee token is a first party contract with expected behavior.
         // slither-disable-next-line unused-return

--- a/src/settlement-chain/interfaces/IDistributionManager.sol
+++ b/src/settlement-chain/interfaces/IDistributionManager.sol
@@ -105,6 +105,9 @@ interface IDistributionManager is IMigratable, IRegistryParametersErrors {
     /// @notice Thrown when there is no change to an updated parameter.
     error NoChange();
 
+    /// @notice Thrown when the protocol fees recipient address is zero (i.e. address(0)).
+    error ZeroProtocolFeeRecipient();
+
     /* ============ Initialization ============ */
 
     /**

--- a/test/unit/DistributionManager.t.sol
+++ b/test/unit/DistributionManager.t.sol
@@ -576,6 +576,13 @@ contract DistributionManagerTests is Test {
         _manager.withdrawProtocolFees();
     }
 
+    function test_withdrawProtocolFees_zeroProtocolFeeRecipient() external {
+        _manager.__setProtocolFeesRecipient(address(0));
+
+        vm.expectRevert(IDistributionManager.ZeroProtocolFeeRecipient.selector);
+        _manager.withdrawProtocolFees();
+    }
+
     function test_withdrawProtocolFees_partial_noPayerRegistryExcess() external {
         _manager.__setProtocolFeesRecipient(address(1));
         _manager.__setOwedProtocolFees(10);
@@ -744,6 +751,13 @@ contract DistributionManagerTests is Test {
         _manager.__setPauseStatus(true);
 
         vm.expectRevert(IDistributionManager.Paused.selector);
+        _manager.withdrawProtocolFeesIntoUnderlying();
+    }
+
+    function test_withdrawProtocolFeesIntoUnderlying_zeroProtocolFeeRecipient() external {
+        _manager.__setProtocolFeesRecipient(address(0));
+
+        vm.expectRevert(IDistributionManager.ZeroProtocolFeeRecipient.selector);
         _manager.withdrawProtocolFeesIntoUnderlying();
     }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Guard `DistributionManager.withdrawProtocolFees` and `DistributionManager.withdrawProtocolFeesIntoUnderlying` to revert with `ZeroProtocolFeeRecipient` when the protocol fees recipient is `address(0)` to prevent zero-address withdrawals (XMTP-11)
This change adds zero-address guards to protocol fee withdrawal paths and defines a custom error for signaling a zero recipient. It updates the `DistributionManager` external withdrawal methods to check the configured protocol fees recipient and revert before initiating transfers or underlying withdrawals, and adds unit tests for the new failure mode.

- Add zero-address guard in `DistributionManager.withdrawProtocolFees` in [DistributionManager.sol](https://github.com/xmtp/smart-contracts/pull/166/files#diff-13865dcd192ab96ef2fe95fcf550b7957883271fe85745961659db93987ccbdd) to revert with `IDistributionManager.ZeroProtocolFeeRecipient` when the recipient is `address(0)`
- Add zero-address guard in `DistributionManager.withdrawProtocolFeesIntoUnderlying` in [DistributionManager.sol](https://github.com/xmtp/smart-contracts/pull/166/files#diff-13865dcd192ab96ef2fe95fcf550b7957883271fe85745961659db93987ccbdd) to revert with `IDistributionManager.ZeroProtocolFeeRecipient` when the recipient is `address(0)`
- Declare `ZeroProtocolFeeRecipient` in the `IDistributionManager` interface in [IDistributionManager.sol](https://github.com/xmtp/smart-contracts/pull/166/files#diff-0b8c7bdf5edef40b81214440ac9b1ea970dd55e7c0d229b416d8469c00b286e7)
- Add unit tests for zero-address recipient reverts in [DistributionManager.t.sol](https://github.com/xmtp/smart-contracts/pull/166/files#diff-4d14e9d93d94bc2fee2be6948987c06422fa9fe459fff85b0e2b6d6f3355fe7e)

#### 📍Where to Start
Start with the zero-address guard added to `DistributionManager.withdrawProtocolFees` in [DistributionManager.sol](https://github.com/xmtp/smart-contracts/pull/166/files#diff-13865dcd192ab96ef2fe95fcf550b7957883271fe85745961659db93987ccbdd), then review the corresponding guard in `DistributionManager.withdrawProtocolFeesIntoUnderlying` and the `ZeroProtocolFeeRecipient` error declaration in [IDistributionManager.sol](https://github.com/xmtp/smart-contracts/pull/166/files#diff-0b8c7bdf5edef40b81214440ac9b1ea970dd55e7c0d229b416d8469c00b286e7).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2fc7ba2. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol fee withdrawal operations will now be rejected if no recipient address is configured, preventing incomplete transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->