### PR TITLE
rename: `FirstTimeInitializable` (Audit S2)

### DIFF
--- a/src/any-chain/Factory.sol
+++ b/src/any-chain/Factory.sol
@@ -3,15 +3,15 @@ pragma solidity 0.8.28;
 
 import { Create2 } from "../../lib/oz/contracts/utils/Create2.sol";
 
-import { Initializable as OZInitializable } from "../../lib/oz-upgradeable/contracts/proxy/utils/Initializable.sol";
+import { Initializable } from "../../lib/oz-upgradeable/contracts/proxy/utils/Initializable.sol";
 
 import { RegistryParameters } from "../libraries/RegistryParameters.sol";
 
 import { IFactory } from "./interfaces/IFactory.sol";
-import { IInitializable } from "./interfaces/IInitializable.sol";
+import { IFirstTimeInitializable } from "./interfaces/IFirstTimeInitializable.sol";
 import { IMigratable } from "../abstract/interfaces/IMigratable.sol";
 
-import { Initializable } from "./Initializable.sol";
+import { FirstTimeInitializable } from "./FirstTimeInitializable.sol";
 import { Migratable } from "../abstract/Migratable.sol";
 import { Proxy } from "./Proxy.sol";
 
@@ -25,7 +25,7 @@ import { Proxy } from "./Proxy.sol";
  *         of freedom. This is helpful for ensuring the address of a future/planned contract is constant, while the
  *         implementation is not yet finalized or deployed.
  */
-contract Factory is IFactory, Migratable, OZInitializable {
+contract Factory is IFactory, Migratable, Initializable {
     /* ============ Constants/Immutables ============ */
 
     /// @inheritdoc IFactory
@@ -79,7 +79,7 @@ contract Factory is IFactory, Migratable, OZInitializable {
     /// @inheritdoc IFactory
     function initialize() external initializer {
         emit InitializableImplementationDeployed(
-            _getFactoryStorage().initializableImplementation = address(new Initializable())
+            _getFactoryStorage().initializableImplementation = address(new FirstTimeInitializable())
         );
     }
 
@@ -115,7 +115,7 @@ contract Factory is IFactory, Migratable, OZInitializable {
         emit ProxyDeployed(proxy_, implementation_, msg.sender, salt_, initializeCallData_);
 
         // Initialize the proxy, which will set its intended implementation slot and initialize it.
-        IInitializable(proxy_).initialize(implementation_, initializeCallData_);
+        IFirstTimeInitializable(proxy_).initialize(implementation_, initializeCallData_);
     }
 
     /// @inheritdoc IMigratable

--- a/src/any-chain/FirstTimeInitializable.sol
+++ b/src/any-chain/FirstTimeInitializable.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import { IInitializable } from "./interfaces/IInitializable.sol";
+import { IFirstTimeInitializable } from "./interfaces/IFirstTimeInitializable.sol";
 
-// TODO: Consider renaming this contract to `AtomicInitializable` and having it inherit from OZ's `Initializable` so it
-//       can check and guarantee the initialization status of the proxy contract itself.
+// TODO: Consider inheriting from OZ's `Initializable` so it can check and guarantee the initialization status of the
+//       proxy contract itself.
 
 /**
  * @title Implementation for first-time atomic initializing of a proxy to an implementation with initialization
@@ -14,7 +14,7 @@ import { IInitializable } from "./interfaces/IInitializable.sol";
  *        very helpful to allow consistency in address determinism regardless the final intended proxied implementation
  *        address. Thus, no Proxy should be left in a state of proxying this contract.
  */
-contract Initializable is IInitializable {
+contract FirstTimeInitializable is IFirstTimeInitializable {
     /**
      * @dev Storage slot with the address of the current implementation.
      *      `keccak256('eip1967.proxy.implementation') - 1`.
@@ -23,7 +23,7 @@ contract Initializable is IInitializable {
 
     /* ============ Interactive Functions ============ */
 
-    /// @inheritdoc IInitializable
+    /// @inheritdoc IFirstTimeInitializable
     function initialize(address implementation_, bytes calldata initializeCallData_) external {
         if (implementation_ == address(0)) revert ZeroImplementation();
 

--- a/src/any-chain/interfaces/IFirstTimeInitializable.sol
+++ b/src/any-chain/interfaces/IFirstTimeInitializable.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 /**
  * @title Interface for first-time initializing of a proxy to an implementation with initialization arguments.
  */
-interface IInitializable {
+interface IFirstTimeInitializable {
     /// @notice Thrown when the implementation address is zero (i.e. address(0)).
     error ZeroImplementation();
 

--- a/test/unit/Factory.t.sol
+++ b/test/unit/Factory.t.sol
@@ -7,7 +7,7 @@ import { Initializable } from "../../lib/oz-upgradeable/contracts/proxy/utils/In
 
 import { IERC1967 } from "../../src/abstract/interfaces/IERC1967.sol";
 import { IFactory } from "../../src/any-chain/interfaces/IFactory.sol";
-import { IInitializable } from "../../src/any-chain/interfaces/IInitializable.sol";
+import { IFirstTimeInitializable } from "../../src/any-chain/interfaces/IFirstTimeInitializable.sol";
 import { IMigratable } from "../../src/abstract/interfaces/IMigratable.sol";
 import { IRegistryParametersErrors } from "../../src/libraries/interfaces/IRegistryParametersErrors.sol";
 
@@ -151,7 +151,11 @@ contract FactoryTests is Test {
         address foo_ = address(new Foo(uint256(456), uint256(789)));
         address expectedProxy_ = _getExpectedProxy(_alice, 0);
 
-        vm.mockCallRevert(expectedProxy_, abi.encodeWithSelector(IInitializable.initialize.selector, foo_, ""), "");
+        vm.mockCallRevert(
+            expectedProxy_,
+            abi.encodeWithSelector(IFirstTimeInitializable.initialize.selector, foo_, ""),
+            ""
+        );
 
         vm.expectRevert();
 

--- a/test/unit/FirstTimeInitializable.t.sol
+++ b/test/unit/FirstTimeInitializable.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.28;
 
 import { Test } from "../../lib/forge-std/src/Test.sol";
 
-import { IInitializable } from "../../src/any-chain/interfaces/IInitializable.sol";
+import { IFirstTimeInitializable } from "../../src/any-chain/interfaces/IFirstTimeInitializable.sol";
 
-import { Initializable } from "../../src/any-chain/Initializable.sol";
+import { FirstTimeInitializable } from "../../src/any-chain/FirstTimeInitializable.sol";
 
 import { Utils } from "../utils/Utils.sol";
 
@@ -19,20 +19,20 @@ contract Foo {
     }
 }
 
-contract InitializableTests is Test {
-    Initializable internal _initializable;
+contract FirstTimeInitializableTests is Test {
+    FirstTimeInitializable internal _initializable;
 
     address internal _implementation;
 
     function setUp() external {
-        _initializable = new Initializable();
+        _initializable = new FirstTimeInitializable();
         _implementation = address(new Foo());
     }
 
     /* ============ initialize ============ */
 
     function test_initialize_zeroImplementation() external {
-        vm.expectRevert(IInitializable.ZeroImplementation.selector);
+        vm.expectRevert(IFirstTimeInitializable.ZeroImplementation.selector);
         _initializable.initialize(address(0), "");
     }
 
@@ -50,7 +50,7 @@ contract InitializableTests is Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IInitializable.InitializationFailed.selector,
+                IFirstTimeInitializable.InitializationFailed.selector,
                 abi.encodeWithSelector(Foo.Reverting.selector)
             )
         );
@@ -62,7 +62,7 @@ contract InitializableTests is Test {
     }
 
     function test_initialize_emptyCode() external {
-        vm.expectRevert(abi.encodeWithSelector(IInitializable.EmptyCode.selector, address(1)));
+        vm.expectRevert(abi.encodeWithSelector(IFirstTimeInitializable.EmptyCode.selector, address(1)));
         _initializable.initialize(address(1), abi.encodeWithSelector(Foo.initialize.selector, uint256(1)));
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Rename initialization contracts and interfaces to `FirstTimeInitializable` across Factory and tests to address Audit S2
Update initialization naming across contracts and tests to use `FirstTimeInitializable` and `IFirstTimeInitializable`, and switch OpenZeppelin inheritance to `Initializable`. The `Factory` contract updates references and deploys `FirstTimeInitializable` in its `Factory.initialize()` flow, and tests are adjusted to the new selectors and symbols.

- Replace local `Initializable` contract and interface references with `FirstTimeInitializable` and `IFirstTimeInitializable` in [Factory.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-9de302a94bf05d441b996dbb5edad0d467196856b482287496b07106d3aa5de0)
- Rename contract and file to `FirstTimeInitializable` and update interface import to `IFirstTimeInitializable` in [FirstTimeInitializable.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-32b8b50d95f490f7581bd4a8a0793186da3ea153df2ddb7ab05599f78774c54d)
- Rename interface to `IFirstTimeInitializable` while preserving members in [IFirstTimeInitializable.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-cc1303035c341be8a90a864983eee08bca5e069d98b3da40b0eb0a382b55abd9)
- Update test imports and selectors to `IFirstTimeInitializable.initialize.selector` in [Factory.t.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-781ef2c7126a33b9c66c5e1b6021b278ede0ab2d83ed44e63e687cc14160ffd1) and [FirstTimeInitializable.t.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-103ea12387d92014198917e1a14632db018186d55081fe161631aa2647ca510e)

#### 📍Where to Start
Start with the `Factory.initialize` call path and proxy deployment logic in [Factory.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-9de302a94bf05d441b996dbb5edad0d467196856b482287496b07106d3aa5de0), then review the renamed contract in [FirstTimeInitializable.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-32b8b50d95f490f7581bd4a8a0793186da3ea153df2ddb7ab05599f78774c54d) and the interface in [IFirstTimeInitializable.sol](https://github.com/xmtp/smart-contracts/pull/167/files#diff-cc1303035c341be8a90a864983eee08bca5e069d98b3da40b0eb0a382b55abd9).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 13109b7. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated initialization component naming and interface structure across the system.

* **Tests**
  * Updated test suite to reflect renamed components and their updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->