### PR TITLE
NodeRegistry updateAdmin check for zero address

### DIFF
--- a/src/settlement-chain/NodeRegistry.sol
+++ b/src/settlement-chain/NodeRegistry.sol
@@ -179,6 +179,9 @@ contract NodeRegistry is INodeRegistry, Migratable, ERC721Upgradeable {
     function updateAdmin() external {
         // NOTE: No access control logic is enforced here, since the value is defined by some administered parameter.
         address admin_ = RegistryParameters.getAddressParameter(parameterRegistry, adminParameterKey());
+
+        if (_isZero(admin_)) revert ZeroAdmin();
+
         NodeRegistryStorage storage $ = _getNodeRegistryStorage();
 
         if (admin_ == $.admin) revert NoChange();

--- a/src/settlement-chain/interfaces/INodeRegistry.sol
+++ b/src/settlement-chain/interfaces/INodeRegistry.sol
@@ -138,6 +138,9 @@ interface INodeRegistry is IERC721, IERC721Metadata, IERC721Errors, IMigratable,
     /// @notice Thrown when the caller is not the node owner.
     error NotNodeOwner();
 
+    /// @notice Thrown when the admin is the zero address.
+    error ZeroAdmin();
+
     /* ============ Initialization ============ */
 
     /**

--- a/test/unit/NodeRegistry.t.sol
+++ b/test/unit/NodeRegistry.t.sol
@@ -461,6 +461,14 @@ contract NodeRegistryTests is Test {
         _registry.updateAdmin();
     }
 
+    function test_updateAdmin_zeroAdmin() external {
+        Utils.expectAndMockParameterRegistryGet(_parameterRegistry, _ADMIN_KEY, bytes32(uint256(0)));
+
+        vm.expectRevert(INodeRegistry.ZeroAdmin.selector);
+
+        _registry.updateAdmin();
+    }
+
     function test_updateAdmin_noChange() external {
         _registry.__setAdmin(_admin);
 


### PR DESCRIPTION
In NodeRegistry.updateAdmin() ensure the admin_ address is not equal to address(0). 
Part of audit changes in XMTP-11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent the admin address from being set to an invalid zero address, protecting the system from misconfiguration.

* **Tests**
  * Expanded test coverage to validate admin address assignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->