### PR TITLE
Cheaper _enforceNodeIdsMatchRegistry

### DIFF
--- a/src/settlement-chain/PayerReportManager.sol
+++ b/src/settlement-chain/PayerReportManager.sol
@@ -520,10 +520,10 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
 
         _sortUint32Array(canonicalNodes_);
 
-        // Single-pass comparison: verify nodeIds_ matches sorted canonicalNodes_ and is strictly increasing
+        // Single-pass comparison: verify nodeIds_ matches sorted canonicalNodes_ and is strictly increasing.
         uint32 prev = 0;
 
-        for (uint256 i = 0; i < len; ) {
+        for (uint256 i = 0; i < len; ++i) {
             uint32 actualId = nodeIds_[i];
             uint32 expectedId = canonicalNodes_[i];
 
@@ -534,10 +534,6 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
             }
 
             prev = actualId;
-
-            unchecked {
-                ++i;
-            }
         }
     }
 
@@ -545,7 +541,7 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
         uint256 len = array_.length;
 
         // Insertion sort - O(n²) worst case but O(n) best case, efficient for small/nearly-sorted arrays.
-        for (uint256 i = 1; i < len; ) {
+        for (uint256 i = 1; i < len; ++i) {
             uint32 key = array_[i];
             uint256 j = i;
 
@@ -558,10 +554,6 @@ contract PayerReportManager is IPayerReportManager, Initializable, Migratable, E
             }
 
             array_[j] = key;
-
-            unchecked {
-                ++i;
-            }
         }
     }
 }

--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -270,12 +270,22 @@ contract PayerReportManagerTests is Test {
         );
         Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getSigner(uint32)", 1), abi.encode(_signer1));
 
+        // Canonical nodes can be unsorted - will be sorted by the PayerReportManager.
+        uint32[] memory canonicalNodes_ = new uint32[](3);
+        canonicalNodes_[2] = 1;
+        canonicalNodes_[1] = 2;
+        canonicalNodes_[0] = 3;
+
         uint32[] memory nodeIds_ = new uint32[](3);
         nodeIds_[0] = 1;
         nodeIds_[1] = 2;
         nodeIds_[2] = 3;
 
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getCanonicalNodes()"), abi.encode(nodeIds_));
+        Utils.expectAndMockCall(
+            _nodeRegistry,
+            abi.encodeWithSignature("getCanonicalNodes()"),
+            abi.encode(canonicalNodes_)
+        );
 
         IPayerReportManager.PayerReportSignature[] memory signatures_ = new IPayerReportManager.PayerReportSignature[](
             1
@@ -454,7 +464,6 @@ contract PayerReportManagerTests is Test {
             })
         });
 
-
         uint32[] memory nodeIds_ = new uint32[](3);
         nodeIds_[0] = 1;
         nodeIds_[1] = 2;
@@ -594,7 +603,11 @@ contract PayerReportManagerTests is Test {
         canonicalNodes_[1] = 2;
         canonicalNodes_[2] = 4;
 
-        Utils.expectAndMockCall(_nodeRegistry, abi.encodeWithSignature("getCanonicalNodes()"), abi.encode(canonicalNodes_));
+        Utils.expectAndMockCall(
+            _nodeRegistry,
+            abi.encodeWithSignature("getCanonicalNodes()"),
+            abi.encode(canonicalNodes_)
+        );
 
         // Submit an incorrect canonical list (length mismatch here)
         uint32[] memory nodeIds_ = new uint32[](2);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Enforce strict, index-aligned matching of provided `nodeIds_` to sorted canonical nodes in `PayerReportManager._enforceNodeIdsMatchRegistry`
Sort the canonical node list and require `nodeIds_` to be strictly increasing and to exactly match the sorted canonical node IDs at each index; add `_sortUint32Array` insertion sort helper and update tests to mock `NodeRegistry.getCanonicalNodes()` and provide ordered `nodeIds_` inputs.

#### 📍Where to Start
Start at the enforcement entrypoint in `PayerReportManager._enforceNodeIdsMatchRegistry` in [file:src/settlement-chain/PayerReportManager.sol].

<!-- Macroscope's changelog starts here -->
#### Changes since #184 opened

- Replaced manual loop increments with for-loop header increments in PayerReportManager contract methods [1621b5a]
- Updated PayerReportManagerTests to test sorting functionality with unsorted input data [1621b5a]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e04422e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened node validation to require exact, ordered alignment with the canonical node set and to fail fast on mismatches or non-increasing node sequences.

* **Tests**
  * Updated test suites and mocks to use canonical node lists and to assert the new ordering and validation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->