### PR TITLE
Cursor rule to suggest increasing contract version number

### DIFF
--- a/.cursor/rules/standards-and-styles.mdc
+++ b/.cursor/rules/standards-and-styles.mdc
@@ -115,3 +115,23 @@ globs: **/*.sol
 - Extract repeated code into reusable functions.
 - Share common logic through proper abstraction.
 - Maintain single sources of truth. For example, if there is some formula to compute `foo` from `bar` and `baz` whcih is not obivous, it should live in its own pure function and used throughout the code.
+
+## Version Management
+- Anytime any change is made to a contract that affects its bytecode, and that contract contains an external `version()` function, remember to suggest bumping that version according to semantic versioning:
+  - **Major version** (X.0.0): Breaking changes that require users to update their code or integrations:
+    - Removing functions
+    - Changing function signatures (parameter types, return types, parameter order)
+    - Removing state variables that are part of the public interface
+    - Changing function behavior in ways that break existing integrations
+  - **Minor version** (0.X.0): New features and additions that are backward compatible:
+    - Adding new functions
+    - Adding new state variables
+    - Adding new events
+    - Extending functionality without breaking existing behavior
+  - **Patch version** (0.0.X): Bug fixes, non-breaking changes, and any change that affects bytecode but not functionality:
+    - Fixing bugs in existing functions
+    - Changing comments (because comments affect the metadata hash, which is part of the bytecode)
+    - Refactoring that doesn't change external behavior
+    - Changing access modifiers of internal/private functions
+    - Any other change that results in different compiled bytecode but maintains the same external interface and behavior
+- When you detect such changes, always remind the user to update the `version()` function return value to reflect the appropriate version bump, and suggest what the new version should be.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add a rule to the Solidity standards guide to require bumping contract semantic versions and updating `contract.version()` when bytecode changes in [.cursor/rules/standards-and-styles.mdc](https://github.com/xmtp/smart-contracts/pull/208/files#diff-754f6a4512e2568daffec9e28880d580c238ac023bc6e39d8672f0669b819462)
Add a "Version Management" section that specifies when to bump major, minor, or patch versions for contracts exposing `contract.version()` and instructs updating the function return value on any bytecode-affecting change.

#### 📍Where to Start
Start with the "Version Management" section in [.cursor/rules/standards-and-styles.mdc](https://github.com/xmtp/smart-contracts/pull/208/files#diff-754f6a4512e2568daffec9e28880d580c238ac023bc6e39d8672f0669b819462).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 5cbd69d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Solidity documentation with new Version Management guidelines section. Details semantic versioning standards for smart contracts with external version() functions, defining Major, Minor, and Patch increment criteria with illustrative examples of version-triggering changes. Includes best practices for synchronizing version declarations with contract modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->