### PR TITLE
PayerReportManager _sortUint32Array test suite

### DIFF
--- a/test/unit/PayerReportManager.t.sol
+++ b/test/unit/PayerReportManager.t.sol
@@ -1389,6 +1389,7 @@ contract PayerReportManagerTests is Test {
             assertEq(payerReports_[1].nodeIds[index_], 10 + index_);
         }
     }
+
     function test_getPayerReports_noReportsForOriginator() external {
         uint32[] memory nodeIds_ = new uint32[](8);
 
@@ -1524,6 +1525,104 @@ contract PayerReportManagerTests is Test {
 
         vm.expectRevert(IPayerReportManager.PayerReportIndexOutOfBounds.selector);
         _manager.getPayerReport(1, 1);
+    }
+
+    /* ============ _sortUint32Array ============ */
+
+    function test_internal_sortUint32Array_empty() external {
+        uint32[] memory array_ = new uint32[](0);
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_.length, 0);
+    }
+
+    function test_internal_sortUint32Array_singleElement() external {
+        uint32[] memory array_ = new uint32[](1);
+        array_[0] = 42;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_.length, 1);
+        assertEq(array_[0], 42);
+    }
+
+    function test_internal_sortUint32Array_twoElements_unsorted() external {
+        uint32[] memory array_ = new uint32[](2);
+        array_[0] = 5;
+        array_[1] = 2;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_[0], 2);
+        assertEq(array_[1], 5);
+    }
+
+    function test_internal_sortUint32Array_twoElements_sorted() external {
+        uint32[] memory array_ = new uint32[](2);
+        array_[0] = 2;
+        array_[1] = 5;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_[0], 2);
+        assertEq(array_[1], 5);
+    }
+
+    function test_internal_sortUint32Array_unsorted() external {
+        uint32[] memory array_ = new uint32[](3);
+        array_[0] = 3;
+        array_[1] = 2;
+        array_[2] = 1;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_[0], 1);
+        assertEq(array_[1], 2);
+        assertEq(array_[2], 3);
+    }
+
+    function test_internal_sortUint32Array_sorted() external {
+        uint32[] memory array_ = new uint32[](3);
+        array_[0] = 1;
+        array_[1] = 2;
+        array_[2] = 3;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_[0], 1);
+        assertEq(array_[1], 2);
+        assertEq(array_[2], 3);
+    }
+
+    function test_internal_sortUint32Array_partiallySorted() external {
+        uint32[] memory array_ = new uint32[](5);
+        array_[0] = 1;
+        array_[1] = 3;
+        array_[2] = 2;
+        array_[3] = 5;
+        array_[4] = 4;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_[0], 1);
+        assertEq(array_[1], 2);
+        assertEq(array_[2], 3);
+        assertEq(array_[3], 4);
+        assertEq(array_[4], 5);
+    }
+
+    function test_internal_sortUint32Array_largeValues() external {
+        uint32[] memory array_ = new uint32[](3);
+        array_[0] = type(uint32).max;
+        array_[1] = 0;
+        array_[2] = type(uint32).max - 1;
+
+        array_ = _manager.__sortUint32Array(array_);
+
+        assertEq(array_[0], 0);
+        assertEq(array_[1], type(uint32).max - 1);
+        assertEq(array_[2], type(uint32).max);
     }
 
     /* ============ DOMAIN_SEPARATOR ============ */

--- a/test/utils/Harnesses.sol
+++ b/test/utils/Harnesses.sol
@@ -588,6 +588,11 @@ contract PayerReportManagerHarness is PayerReportManager {
                 nodeIds_
             );
     }
+
+    function __sortUint32Array(uint32[] memory array_) external pure returns (uint32[] memory sortedArray_) {
+        _sortUint32Array(array_);
+        return array_;
+    }
 }
 
 contract DistributionManagerHarness is DistributionManager {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add unit tests for `PayerReportManager.__sortUint32Array` to verify sorting of empty, single-element, two-element, and boundary-value uint32 arrays
Introduce a harness wrapper and targeted tests that exercise `PayerReportManager.__sortUint32Array` across empty, single, small, partially sorted, and max/0 boundary cases. The harness exposes an external pure method for invoking the internal sorter.

#### 📍Where to Start
Start with the harness method `PayerReportManagerHarness.__sortUint32Array` in [Harnesses.sol](https://github.com/xmtp/smart-contracts/pull/212/files#diff-f803a3747dfd9bb6151512e75424166315fd4e6c591066540f3f690ec7093177), then review test cases in [PayerReportManager.t.sol](https://github.com/xmtp/smart-contracts/pull/212/files#diff-88d841009e835b92dfaa91cbaaca83627d59bcb7e62090ff6a6af09f7ee67bdb).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6df2be7.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for sorting functionality with thorough validation across diverse scenarios including empty arrays, single-element arrays, fully sorted and fully unsorted sequences, partially sorted data, and large numerical value handling. Enhanced test infrastructure with additional helper utilities to strengthen quality assurance and system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->