### PR TITLE
Fix code verification for XMTP mainnet L3

### DIFF
--- a/dev/utils
+++ b/dev/utils
@@ -107,7 +107,7 @@ get_explorer_url() {
         fi
     elif [ "$explorer" = "alchemy" ]; then
         if [ "$environment" = "mainnet" ]; then
-            echo "https://xmtp.explorer.alchemy.com/api/"
+            echo "https://xmtp-mainnet.explorer.alchemy.com/api/"
         else
             echo "https://xmtp-ropsten.explorer.alchemy.com/api/"
         fi


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix `dev/utils:get_explorer_url` to return `https://xmtp-mainnet.explorer.alchemy.com/api/` for XMTP mainnet L3 verification
Update the `dev/utils:get_explorer_url` shell function to echo the Alchemy API URL `https://xmtp-mainnet.explorer.alchemy.com/api/` when `explorer=alchemy` and `environment=mainnet`.

#### 📍Where to Start
Start with the `get_explorer_url` function in [dev/utils](https://github.com/xmtp/smart-contracts/pull/227/files#diff-7b121917c3cc61267d76d42ae7be5d610722ba9bfe326af93a4e9e904c5b8282).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 62876e8.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Alchemy explorer API endpoint for mainnet to resolve connectivity issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->