### PR TITLE
Clarify units

### DIFF
--- a/doc/parameter-registry.md
+++ b/doc/parameter-registry.md
@@ -28,6 +28,8 @@ This document illustrates the complete process of setting a parameter in the XMT
 
 XMTP uses a comprehensive parameter system to manage configuration across all contracts. Parameters are organized by contract and functionality, using a hierarchical key structure. All parameter keys follow the pattern `xmtp.{contract}.{parameter}`.
 
+Some parameters are amounts denominated in picodollars. Note that 1 dollar = 1,000,000,000,000 (10¹²) picodollars.
+
 ### XMTP Settlement Chain parameters
 
 #### XMTP Settlement Chain parameter registry


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Clarify units in parameter documentation by specifying payer minimumDeposit in wei and rate registry fees in picodollars in [parameter-registry.md](https://github.com/xmtp/smart-contracts/pull/245/files#diff-685a6d59827eee712ba4524ad72acfbf612b6a1995ac4b12424ac9f1fd79ea75)
Update [parameter-registry.md](https://github.com/xmtp/smart-contracts/pull/245/files#diff-685a6d59827eee712ba4524ad72acfbf612b6a1995ac4b12424ac9f1fd79ea75) to state payer `minimumDeposit` in wei units and define `messageFee`, `storageFee`, and `congestionFee` in picodollars; standardize section names and terminology across the document.

#### 📍Where to Start
Start with the fee and deposit unit definitions in [parameter-registry.md](https://github.com/xmtp/smart-contracts/pull/245/files#diff-685a6d59827eee712ba4524ad72acfbf612b6a1995ac4b12424ac9f1fd79ea75), focusing on the payer registry `minimumDeposit` and rate registry fee entries.

<!-- Macroscope's changelog starts here -->
#### Changes since #245 opened

- Added clarification note in parameter registry documentation specifying that parameters are denominated in picodollars with conversion rate of 1 dollar equals 1,000,000,000,000 picodollars [bc8d1a6]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized bb0e248.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised parameter registry headings and subsection titles for consistent capitalization and clearer hierarchy (XMTP Settlement Chain / XMTP App Chain).
  * Added global note clarifying picodollar denomination and equivalence (1 dollar = 10^12 picodollars).
  * Clarified units: minimum deposit now specified in wei; rate registry fees (message, storage, congestion) specified in picodollars.
  * Preserved existing parameter keys and overall structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->