### PR TITLE
Update deployed RateRegistry Contract Address

### DIFF
--- a/config/testnet-dev.json
+++ b/config/testnet-dev.json
@@ -34,7 +34,7 @@
   "payerReportManagerImplementation": "0x6c01f5F69073Bde8b8A1174d2F378ED9F1Fb5752",
   "payerReportManagerProxy": "0x68F76B099B017CBC65EF5c4c99614843d82DaCAD",
   "payerReportManagerProxySalt": "PayerReportManager_0_3",
-  "rateRegistryImplementation": "0xBa0479d260e3276142Ba338dfC5498407e1d4063",
+  "rateRegistryImplementation": "0xb7cd7F1E889DBe2Dd89B280864981418a8F6F9Bb",
   "rateRegistryProxy": "0x89C6Aa3e03224F43290823471E8ed725C35bAcCE",
   "rateRegistryProxySalt": "RateRegistry_0_0",
   "settlementChainGatewayImplementation": "0x6748bfc9ce3bbF672E93A5beD18043B73600072B",

--- a/config/testnet-staging.json
+++ b/config/testnet-staging.json
@@ -34,7 +34,7 @@
   "payerReportManagerImplementation": "0x3853e90e5E80bc42fb3726e0C75E8f4Db3c49194",
   "payerReportManagerProxy": "0x868132030B97457582630456ACBe6bD303F17263",
   "payerReportManagerProxySalt": "PayerReportManager_1_1",
-  "rateRegistryImplementation": "0x52CA9E42b720b562AC652665b007c85142A8DD34",
+  "rateRegistryImplementation": "0xb7cd7F1E889DBe2Dd89B280864981418a8F6F9Bb",
   "rateRegistryProxy": "0xA112D3E611a6a2F06F435FdE3B3912469cc6EE3f",
   "rateRegistryProxySalt": "RateRegistry_1_0",
   "settlementChainGatewayImplementation": "0xaf3c0F769c9Bc5BbDDb475a08a0a8b160519efdf",


### PR DESCRIPTION
gi### TL;DR

Updated the `rateRegistryImplementation` address in both testnet-dev and testnet-staging configuration files.

### What changed?

- Changed the `rateRegistryImplementation` address in `config/testnet-dev.json` from `0xBa0479d260e3276142Ba338dfC5498407e1d4063` to `0xb7cd7F1E889DBe2Dd89B280864981418a8F6F9Bb`
- Changed the `rateRegistryImplementation` address in `config/testnet-staging.json` from `0x52CA9E42b720b562AC652665b007c85142A8DD34` to `0xb7cd7F1E889DBe2Dd89B280864981418a8F6F9Bb`

### How to test?

1. Verify that the new implementation address `0xb7cd7F1E889DBe2Dd89B280864981418a8F6F9Bb` is correctly deployed and contains the expected contract code
2. Ensure that the RateRegistry proxies in both environments point to the correct implementation
3. Test the functionality of the RateRegistry in both testnet-dev and testnet-staging environments

### Why make this change?

This change standardizes the RateRegistry implementation address across both testnet environments, likely to ensure consistent behavior and simplify maintenance. The new implementation may contain bug fixes or feature improvements that need to be deployed to both environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rate registry implementation configuration across testnet development and staging environments to synchronize deployment specifications and maintain consistency in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->