### PR TITLE
Claude skill to propose commands should default to including --broadcast (it still never executes anything)

### DIFF
--- a/.claude/skills/xmtp-set-parameter/SKILL.md
+++ b/.claude/skills/xmtp-set-parameter/SKILL.md
@@ -9,7 +9,7 @@ description: >
 argument-hint: [action] [key] [value] [environment] [signing-mode]
 metadata:
   author: XMTP
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 ## CRITICAL CONSTRAINT — PROPOSE ONLY, NEVER EXECUTE
@@ -84,7 +84,7 @@ Accept fuzzy descriptions from the user (e.g. "set max nodes to 100 on testnet-d
 - Include `export ENVIRONMENT=<env>` and `export ADMIN_ADDRESS_TYPE=<type>` as prerequisite steps.
 - For reads, note that `--broadcast` and `--slow` should be omitted — these are view-only calls.
 - For Fireblocks: include `export FIREBLOCKS_NOTE="<description>"` as a step, with a human-readable description of the parameter change.
-- If the user did not specify `--broadcast`, compose the commands as dry runs (without `--broadcast`). Note this in the plan.
+- Always include `--broadcast` in set and bridge commands. Do not produce dry runs unless user specifically asks.
 
 ## Examples
 

--- a/.claude/skills/xmtp-upgrade/SKILL.md
+++ b/.claude/skills/xmtp-upgrade/SKILL.md
@@ -10,7 +10,7 @@ description: >
 argument-hint: [contract] [environment] [signing-mode]
 metadata:
   author: XMTP
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 ## CRITICAL CONSTRAINT — PROPOSE ONLY, NEVER EXECUTE
@@ -94,7 +94,7 @@ Accept fuzzy names from the user (e.g. "node registry", "payer report manager", 
    - Include the verify-contract command from the Post-Upgrade section of the README.
    - If the user asks to skip the state check, note that they should add `export SKIP_STATE_CHECK=true` to the prerequisites.
 
-7. If the user did not specify `--broadcast`, compose all commands as dry runs (without `--broadcast`). Note this in the plan.
+7. Always include `--broadcast` in all transaction-submitting commands. Do not produce dry runs unless user specifically asks.
 
 ## Important rules
 
@@ -107,16 +107,15 @@ Accept fuzzy names from the user (e.g. "node registry", "payer report manager", 
 
 ## Examples
 
-Example 1: Dry-run upgrade with Fireblocks
-User says: "upgrade NodeRegistry on testnet-dev using fireblocks, do a dry run"
+Example 1: Upgrade with Fireblocks
+User says: "upgrade NodeRegistry on testnet-dev using fireblocks"
 Output: a numbered plan containing:
 1. Repo cleanliness check commands
 2. Prerequisite exports (`source .env`, `ENVIRONMENT`, `ADMIN_ADDRESS_TYPE`, `FIREBLOCKS_NOTE`)
 3. `.env` verification note (Fireblocks ADMIN must be uncommented)
-4. Step 1 command (deploy new implementation) without `--broadcast`
-5. Note: this is a dry run — no on-chain transactions will be submitted
+4. Step 1 command (deploy new implementation) with `--broadcast`
 
-Example 2: Full upgrade with wallet signing
+Example 2: Upgrade with wallet signing
 User says: "upgrade the payer report manager on testnet-staging"
 Output: a numbered plan containing:
 1. Repo cleanliness check commands


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow requirements: users must now explicitly include the `--broadcast` flag for transaction-submitting commands
  * Dry runs are no longer default behavior; only available when explicitly requested
  * Revised examples to reflect updated workflow guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->