### PR TITLE
chore: track foundry.lock for reproducible dependency pinning

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,14 @@
+{
+  "lib/forge-std": {
+    "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+  },
+  "lib/oz": {
+    "rev": "e4f70216d759d8e6a64144a9e1f7bbeed78e7079"
+  },
+  "lib/oz-upgradeable": {
+    "rev": "60b305a8f3ff0c7688f02ac470417b6bbf1c4d27"
+  },
+  "lib/solady": {
+    "rev": "a2f53c1f15ed07671d805e3a4a0e306b2a09d3bc"
+  }
+}


### PR DESCRIPTION
The foundry.lock file was introduced in [Foundry PR #9522](https://github.com/foundry-rs/foundry/pull/9522) (merged in Foundry v1.3.0) to solve the git submodules problem - they doesn't natively support pinning to tags or revisions — only branches.

Without the lockfile, running forge update can silently check out dependencies at the latest commit on master instead of the intended tag/revision.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track `foundry.lock` for reproducible dependency pinning
> Adds `foundry.lock` to version control to pin Foundry dependencies at a specific snapshot, ensuring reproducible builds across environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ba8a4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->